### PR TITLE
fix: shopping feature polish, edge cases & UX fixes

### DIFF
--- a/client/src/components/common/BottomSheet.jsx
+++ b/client/src/components/common/BottomSheet.jsx
@@ -4,7 +4,7 @@
  * Uses Framer Motion for animation. Dismisses on backdrop click or drag down.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { motion, AnimatePresence, useDragControls } from 'framer-motion';
 import { X } from 'lucide-react';
 import { cn } from '../../utils/helpers';
@@ -21,6 +21,36 @@ const BottomSheet = ({
 }) => {
   const { t } = useTranslation('common');
   const dragControls = useDragControls();
+
+  // Keep a stable ref to onClose so the history effect doesn't re-run on every render
+  const onCloseRef = useRef(onClose);
+  useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
+
+  // Android back-gesture / hardware back button: push a history entry when the
+  // sheet opens so the gesture hits that entry instead of leaving the app.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Track whether close was triggered by the back gesture (popstate) or
+    // programmatically (X button / backdrop). Only in the latter case do we
+    // need to pop the entry we pushed.
+    let closedByPop = false;
+
+    history.pushState({ bottomSheet: true }, '');
+
+    const handlePop = () => {
+      closedByPop = true;
+      onCloseRef.current();
+    };
+
+    window.addEventListener('popstate', handlePop);
+
+    return () => {
+      window.removeEventListener('popstate', handlePop);
+      // Programmatic close — remove the history entry we pushed
+      if (!closedByPop) history.back();
+    };
+  }, [isOpen]); // intentionally omit onClose — we use the ref
 
   const handleBackdropClick = useCallback((e) => {
     if (e.target === e.currentTarget) onClose();

--- a/client/src/components/common/MobileBottomNav.jsx
+++ b/client/src/components/common/MobileBottomNav.jsx
@@ -10,11 +10,11 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Home, CreditCard, Plus, BarChart3, User,
   PlusCircle, MinusCircle, Tag, RepeatIcon, Calculator,
-  Shield, HelpCircle, Sun, Moon, Globe, LogOut, ShoppingCart,
+  Shield, HelpCircle, Sun, Moon, Globe, ShoppingCart,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '../../utils/helpers';
-import { useTranslation, useIsAdmin, useTheme, useAuth, useNotifications, useTranslationStore } from '../../stores';
+import { useTranslation, useIsAdmin, useTheme, useNotifications, useTranslationStore } from '../../stores';
 import { useToast } from '../../hooks/useToast';
 import { useShoppingShare } from '../../hooks/useShoppingShare';
 import BottomSheet from './BottomSheet';
@@ -25,7 +25,6 @@ const MobileBottomNav = () => {
   const location = useLocation();
   const { t, currentLanguage, setLanguage } = useTranslation();
   const { isDark, setTheme } = useTheme();
-  const { logout } = useAuth();
   const toast = useToast();
   const isAdmin = useIsAdmin();
 
@@ -52,11 +51,6 @@ const MobileBottomNav = () => {
     try { sessionStorage.setItem('spendwise-session-language', newLang); } catch (_) {}
     toast.success(t('toast.settings.languageChangedSession'), { duration: 2000 });
   }, [currentLanguage, setLanguage, toast, t]);
-
-  const handleLogout = useCallback(async () => {
-    setMenuOpen(false);
-    await logout(true);
-  }, [logout]);
 
   const handleClose = useCallback(() => {
     setMenuOpen(false);
@@ -284,7 +278,7 @@ const MobileBottomNav = () => {
             <div className="w-12 h-12 rounded-2xl bg-white/20 flex items-center justify-center flex-shrink-0">
               <ShoppingCart className="w-7 h-7 text-white" strokeWidth={1.75} />
             </div>
-            <div className="text-left">
+            <div className="flex-1 text-start min-w-0">
               <p className="text-base font-bold text-white leading-tight">
                 {t('shopping.title') || 'Shopping List'}
               </p>
@@ -292,7 +286,7 @@ const MobileBottomNav = () => {
                 {t('shopping.manageList') || 'Manage your shared lists'}
               </p>
             </div>
-            <div className="ml-auto">
+            <div className="flex-shrink-0">
               <div className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center">
                 <Plus className="w-5 h-5 text-white" />
               </div>
@@ -361,11 +355,11 @@ const MobileBottomNav = () => {
 
           {/* ── Settings row ─────────────────────────────────────────── */}
           <div className="pt-3 border-t border-gray-100 dark:border-gray-700/60">
-            <div className="flex items-center gap-3">
+            <div className="grid grid-cols-2 gap-3">
               <button
                 onClick={handleThemeToggle}
                 className={cn(
-                  'flex-1 flex flex-col items-center gap-1.5 py-3 rounded-2xl',
+                  'flex flex-col items-center gap-1.5 py-3 rounded-2xl',
                   'bg-white dark:bg-gray-800',
                   'border border-gray-100 dark:border-gray-700/60',
                   'shadow-sm active:scale-95 transition-all duration-150'
@@ -385,7 +379,7 @@ const MobileBottomNav = () => {
               <button
                 onClick={handleLanguageToggle}
                 className={cn(
-                  'flex-1 flex flex-col items-center gap-1.5 py-3 rounded-2xl',
+                  'flex flex-col items-center gap-1.5 py-3 rounded-2xl',
                   'bg-white dark:bg-gray-800',
                   'border border-gray-100 dark:border-gray-700/60',
                   'shadow-sm active:scale-95 transition-all duration-150'
@@ -396,23 +390,6 @@ const MobileBottomNav = () => {
                 </div>
                 <span className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
                   {currentLanguage === 'en' ? t('common.hebrew') : t('common.english')}
-                </span>
-              </button>
-
-              <button
-                onClick={handleLogout}
-                className={cn(
-                  'flex-1 flex flex-col items-center gap-1.5 py-3 rounded-2xl',
-                  'bg-white dark:bg-gray-800',
-                  'border border-red-100 dark:border-red-900/40',
-                  'shadow-sm active:scale-95 transition-all duration-150'
-                )}
-              >
-                <div className="w-10 h-10 rounded-xl flex items-center justify-center bg-gradient-to-br from-red-400 to-rose-600 shadow-md shadow-red-400/30">
-                  <LogOut className="w-5 h-5 text-white" strokeWidth={1.75} />
-                </div>
-                <span className="text-[11px] font-semibold text-red-600 dark:text-red-400">
-                  {t('common.logout') || 'Logout'}
                 </span>
               </button>
             </div>

--- a/client/src/components/common/MobileBottomNav.jsx
+++ b/client/src/components/common/MobileBottomNav.jsx
@@ -395,7 +395,7 @@ const MobileBottomNav = () => {
                   <Globe className="w-5 h-5 text-white" strokeWidth={1.75} />
                 </div>
                 <span className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
-                  {currentLanguage === 'en' ? 'עברית' : 'English'}
+                  {currentLanguage === 'en' ? t('common.hebrew') : t('common.english')}
                 </span>
               </button>
 

--- a/client/src/components/features/shopping/ShoppingBottomSheet.jsx
+++ b/client/src/components/features/shopping/ShoppingBottomSheet.jsx
@@ -50,7 +50,7 @@ const ErrorMsg = ({ msg }) => (
 );
 
 const ShoppingBottomSheet = ({ isOpen, onClose, onSave, editItem = null, isSaving = false }) => {
-  const { t } = useTranslation('shopping');
+  const { t, isRTL } = useTranslation('shopping');
   const [form, setForm] = useState(EMPTY);
   const [errors, setErrors] = useState({});
   const nameRef = useRef(null);
@@ -108,7 +108,7 @@ const ShoppingBottomSheet = ({ isOpen, onClose, onSave, editItem = null, isSavin
       title={editItem ? t('sheet.editTitle') : t('sheet.addTitle')}
       height="auto"
     >
-      <div className="flex flex-col gap-5 pb-6" dir="rtl">
+      <div className="flex flex-col gap-5 pb-6">
 
         {/* Name */}
         <div>

--- a/client/src/components/features/shopping/ShoppingBottomSheet.jsx
+++ b/client/src/components/features/shopping/ShoppingBottomSheet.jsx
@@ -10,12 +10,12 @@ import { cn } from '../../../utils/helpers';
 import { useTranslation } from '../../../stores';
 
 export const CATEGORIES = [
-  { value: 'ריהוט',       key: 'furniture',    color: 'bg-amber-100 text-amber-700 border-amber-200',   dot: 'bg-amber-500'  },
-  { value: 'מטבח',        key: 'kitchen',      color: 'bg-orange-100 text-orange-700 border-orange-200', dot: 'bg-orange-500' },
-  { value: 'חדר שינה',    key: 'bedroom',      color: 'bg-purple-100 text-purple-700 border-purple-200', dot: 'bg-purple-500' },
-  { value: 'אלקטרוניקה',  key: 'electronics',  color: 'bg-blue-100 text-blue-700 border-blue-200',       dot: 'bg-blue-500'   },
-  { value: 'ביגוד',       key: 'clothing',     color: 'bg-pink-100 text-pink-700 border-pink-200',       dot: 'bg-pink-500'   },
-  { value: 'אחר',         key: 'other',        color: 'bg-gray-100 text-gray-600 border-gray-200',       dot: 'bg-gray-400'   },
+  { value: 'ריהוט',       key: 'furniture',    emoji: '🛋️',  color: 'bg-amber-100 text-amber-700 border-amber-200',   dot: 'bg-amber-500'  },
+  { value: 'מטבח',        key: 'kitchen',      emoji: '🍳',  color: 'bg-orange-100 text-orange-700 border-orange-200', dot: 'bg-orange-500' },
+  { value: 'חדר שינה',    key: 'bedroom',      emoji: '🛏️',  color: 'bg-purple-100 text-purple-700 border-purple-200', dot: 'bg-purple-500' },
+  { value: 'אלקטרוניקה',  key: 'electronics',  emoji: '📱',  color: 'bg-blue-100 text-blue-700 border-blue-200',       dot: 'bg-blue-500'   },
+  { value: 'ביגוד',       key: 'clothing',     emoji: '👕',  color: 'bg-pink-100 text-pink-700 border-pink-200',       dot: 'bg-pink-500'   },
+  { value: 'אחר',         key: 'other',        emoji: '📦',  color: 'bg-gray-100 text-gray-600 border-gray-200',       dot: 'bg-gray-400'   },
 ];
 
 const EMPTY = { name: '', category: 'אחר', price_ils: '', buy_url: '', notes: '' };
@@ -136,19 +136,23 @@ const ShoppingBottomSheet = ({ isOpen, onClose, onSave, editItem = null, isSavin
                 <motion.button
                   key={cat.value}
                   type="button"
-                  whileTap={{ scale: 0.95 }}
+                  whileTap={{ scale: 0.93 }}
                   onClick={() => set('category', cat.value)}
                   className={cn(
-                    'flex items-center gap-2 px-3 py-2.5 rounded-xl border text-xs font-semibold',
-                    'transition-all duration-150 min-h-[44px] justify-center',
+                    'relative flex flex-col items-center gap-1.5 px-2 py-3 rounded-2xl border',
+                    'transition-all duration-150 min-h-[64px] justify-center',
                     active
-                      ? cn(cat.color, 'shadow-md scale-[1.02]')
-                      : 'bg-white/70 border-gray-200 text-gray-500 hover:border-gray-300 dark:bg-gray-800/70 dark:border-gray-700 dark:text-gray-400'
+                      ? cn(cat.color, 'shadow-lg scale-[1.04] border-current')
+                      : 'bg-white/70 border-gray-200 text-gray-400 hover:border-gray-300 dark:bg-gray-800/70 dark:border-gray-700'
                   )}
                 >
-                  <span className={cn('w-2 h-2 rounded-full flex-shrink-0', active ? cat.dot : 'bg-gray-300 dark:bg-gray-600')} />
-                  {t(`categories.${cat.key}`)}
-                  {active && <Check className="w-3 h-3 mr-auto" strokeWidth={2.5} />}
+                  {active && (
+                    <span className="absolute top-1.5 left-1.5 w-3.5 h-3.5 rounded-full bg-current/20 flex items-center justify-center">
+                      <Check className="w-2.5 h-2.5" strokeWidth={3} />
+                    </span>
+                  )}
+                  <span className={cn('text-xl leading-none', !active && 'grayscale opacity-60')}>{cat.emoji}</span>
+                  <span className="text-[11px] font-bold leading-tight text-center">{t(`categories.${cat.key}`)}</span>
                 </motion.button>
               );
             })}

--- a/client/src/components/features/shopping/ShoppingItemCard.jsx
+++ b/client/src/components/features/shopping/ShoppingItemCard.jsx
@@ -1,190 +1,224 @@
 /**
- * ShoppingItemCard — single shopping list item, claymorphic card
+ * ShoppingItemCard — premium redesign
  */
 
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Pencil, Trash2, ExternalLink, CheckCircle2, Circle } from 'lucide-react';
+import { Pencil, Trash2, ExternalLink, Check } from 'lucide-react';
 import { cn, currency } from '../../../utils/helpers';
 import { CATEGORIES } from './ShoppingBottomSheet';
 import { useTranslation } from '../../../stores';
+
+// Subtle category-tinted card backgrounds
+const CAT_BG = {
+  'bg-amber-500':  'bg-gradient-to-bl from-amber-50/70 to-white dark:from-amber-900/10 dark:to-gray-800',
+  'bg-orange-500': 'bg-gradient-to-bl from-orange-50/70 to-white dark:from-orange-900/10 dark:to-gray-800',
+  'bg-purple-500': 'bg-gradient-to-bl from-purple-50/70 to-white dark:from-purple-900/10 dark:to-gray-800',
+  'bg-blue-500':   'bg-gradient-to-bl from-blue-50/70 to-white dark:from-blue-900/10 dark:to-gray-800',
+  'bg-pink-500':   'bg-gradient-to-bl from-pink-50/70 to-white dark:from-pink-900/10 dark:to-gray-800',
+  'bg-gray-400':   'bg-gradient-to-bl from-gray-50/80 to-white dark:from-gray-700/20 dark:to-gray-800',
+};
 
 const ShoppingItemCard = ({ item, onEdit, onDelete, onToggleBought, isDeleting }) => {
   const { t } = useTranslation('shopping');
   const [confirmDelete, setConfirmDelete] = useState(false);
   const timeoutRef = useRef(null);
 
-  // Clear confirm-delete timer on unmount or when already confirmed
   useEffect(() => {
     if (!confirmDelete) return;
     timeoutRef.current = setTimeout(() => setConfirmDelete(false), 3000);
     return () => clearTimeout(timeoutRef.current);
   }, [confirmDelete]);
 
-  const cat = CATEGORIES.find((c) => c.value === item.category) || CATEGORIES[5];
+  const cat    = CATEGORIES.find((c) => c.value === item.category) || CATEGORIES[5];
   const bought = item.is_bought;
+  const price  = parseFloat(item.price_ils) || 0;
+  const cardBg = CAT_BG[cat.dot] || CAT_BG['bg-gray-400'];
 
   const handleDeleteClick = () => {
-    if (confirmDelete) {
-      onDelete(item.id);
-      setConfirmDelete(false);
-    } else {
-      setConfirmDelete(true);
-    }
+    if (confirmDelete) { onDelete(item.id); setConfirmDelete(false); }
+    else setConfirmDelete(true);
   };
 
   return (
     <motion.div
       layout
       initial={{ opacity: 0, y: 16, scale: 0.97 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
+      animate={{ opacity: bought ? 0.65 : 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95, y: -8 }}
       transition={{ type: 'spring', stiffness: 380, damping: 28 }}
       className={cn(
-        'relative rounded-2xl border bg-white',
-        'shadow-[0_4px_20px_rgba(0,0,0,0.06),inset_0_1px_0_rgba(255,255,255,0.95)]',
-        'dark:bg-gray-800/90 dark:border-gray-700/60',
-        'overflow-hidden transition-all duration-200',
-        bought && 'opacity-60 grayscale-[30%]'
+        'relative rounded-2xl overflow-hidden',
+        'border border-gray-100 dark:border-gray-700/60',
+        'shadow-[0_2px_12px_rgba(0,0,0,0.06),0_1px_3px_rgba(0,0,0,0.04)]',
+        'transition-shadow hover:shadow-[0_4px_20px_rgba(0,0,0,0.09)]',
+        cardBg
       )}
       dir="rtl"
     >
-      {/* Category accent bar */}
-      <div className={cn('h-1 w-full', cat.dot)} />
+      {/* Right-side category accent (RTL = start side) */}
+      <div className={cn('absolute top-0 right-0 w-[3px] h-full', cat.dot)} />
 
-      <div className="p-4">
-        {/* Top row: name + price */}
-        <div className="flex items-start justify-between gap-3 mb-3">
-          <div className="flex items-start gap-2.5 flex-1 min-w-0">
-            {/* Bought toggle */}
-            <button
-              onClick={() => onToggleBought(item)}
-              disabled={confirmDelete}
-              className="mt-0.5 flex-shrink-0 min-h-[24px] min-w-[24px] flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label={bought ? t('card.markAsNotBought') : t('card.markAsBought')}
-            >
-              {bought
-                ? <CheckCircle2 className="w-5 h-5 text-emerald-500" strokeWidth={2} />
-                : <Circle className="w-5 h-5 text-gray-300 hover:text-blue-400 transition-colors" strokeWidth={2} />
-              }
-            </button>
+      <div className="px-4 pt-4 pb-3 pr-5">
 
+        {/* ── Top row: toggle | name | price ── */}
+        <div className="flex items-center gap-3">
+
+          {/* Toggle — rightmost on screen (first in RTL flex) */}
+          <motion.button
+            onClick={() => onToggleBought(item)}
+            disabled={confirmDelete}
+            whileTap={{ scale: 0.85 }}
+            className={cn(
+              'flex-shrink-0 w-10 h-10 rounded-2xl flex items-center justify-center',
+              'transition-all duration-250 disabled:opacity-40',
+              bought
+                ? 'bg-emerald-500 shadow-md shadow-emerald-400/40'
+                : 'bg-white dark:bg-gray-700/80 border-2 border-gray-200 dark:border-gray-600 shadow-sm'
+            )}
+            aria-label={bought ? t('card.markAsNotBought') : t('card.markAsBought')}
+          >
+            <AnimatePresence mode="wait" initial={false}>
+              {bought ? (
+                <motion.div key="check"
+                  initial={{ scale: 0, rotate: -30 }}
+                  animate={{ scale: 1, rotate: 0 }}
+                  exit={{ scale: 0 }}
+                  transition={{ type: 'spring', stiffness: 500, damping: 25 }}
+                >
+                  <Check className="w-5 h-5 text-white" strokeWidth={3} />
+                </motion.div>
+              ) : (
+                <motion.span
+                  key="dot"
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  exit={{ scale: 0 }}
+                  className={cn('w-3 h-3 rounded-full', cat.dot, 'opacity-40')}
+                />
+              )}
+            </AnimatePresence>
+          </motion.button>
+
+          {/* Name + meta — middle */}
+          <div className="flex-1 min-w-0">
             <h3 className={cn(
-              'text-base font-bold text-gray-800 dark:text-white leading-tight truncate',
-              bought && 'line-through text-gray-400'
+              'text-[15px] font-bold leading-snug',
+              bought
+                ? 'line-through text-gray-400 dark:text-gray-500'
+                : 'text-gray-900 dark:text-white'
             )}>
               {item.name}
             </h3>
+
+            {/* Category + notes inline */}
+            <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+              <span className={cn(
+                'inline-flex items-center gap-1 px-2 py-0.5 rounded-full',
+                'text-[11px] font-semibold border',
+                cat.color
+              )}>
+                <span className="text-sm leading-none">{cat.emoji}</span>
+                {t(`categories.${cat.key}`)}
+              </span>
+              {item.notes && (
+                <span className="text-xs text-gray-400 dark:text-gray-500 truncate max-w-[150px] italic">
+                  {item.notes}
+                </span>
+              )}
+            </div>
           </div>
 
-          {/* Price badge */}
-          {parseFloat(item.price_ils) > 0 && (
-            <span className={cn(
-              'flex-shrink-0 text-sm font-extrabold text-blue-700 dark:text-blue-300',
-              'bg-blue-50 dark:bg-blue-900/30 border border-blue-100 dark:border-blue-800',
-              'px-2.5 py-1 rounded-xl tabular-nums'
-            )}>
-              {currency.format(parseFloat(item.price_ils) || 0)}
-            </span>
+          {/* Price — leftmost on screen (last in RTL flex) */}
+          {price > 0 && (
+            <div className="flex-shrink-0 text-right">
+              <span className={cn(
+                'text-base font-extrabold tabular-nums leading-none',
+                bought
+                  ? 'text-gray-400 dark:text-gray-500 line-through'
+                  : 'text-gray-900 dark:text-white'
+              )}>
+                {currency.format(price)}
+              </span>
+            </div>
           )}
         </div>
 
-        {/* Category chip */}
-        <div className="flex items-center gap-2 mb-3">
-          <span className={cn(
-            'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border',
-            cat.color
-          )}>
-            <span className={cn('w-1.5 h-1.5 rounded-full flex-shrink-0', cat.dot)} />
-            {t(`categories.${cat.key}`)}
-          </span>
-        </div>
+        {/* ── Action row ── */}
+        <div className="flex items-center gap-2 mt-3 pt-2.5 border-t border-gray-100/70 dark:border-gray-700/50">
 
-        {/* Notes */}
-        {item.notes && (
-          <p className="text-xs text-gray-500 dark:text-gray-400 mb-3 leading-relaxed line-clamp-2">
-            {item.notes}
-          </p>
-        )}
-
-        {/* Action row */}
-        <div className="flex items-center gap-2 pt-2 border-t border-gray-100 dark:border-gray-700/50">
-          {/* External link */}
+          {/* Buy Now link */}
           {item.buy_url && (
             <a
               href={item.buy_url}
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                'flex items-center gap-1.5 px-3 py-2 rounded-xl',
-                'bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-100 dark:border-indigo-800',
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-xl',
+                'bg-indigo-50 dark:bg-indigo-900/25 border border-indigo-100 dark:border-indigo-800/60',
                 'text-indigo-600 dark:text-indigo-400 text-xs font-semibold',
-                'hover:bg-indigo-100 transition-colors min-h-[36px]'
+                'hover:bg-indigo-100 dark:hover:bg-indigo-900/40 transition-colors'
               )}
             >
-              <ExternalLink className="w-3.5 h-3.5" strokeWidth={2.5} />
+              <ExternalLink className="w-3 h-3" strokeWidth={2.5} />
               {t('card.buyNow')}
             </a>
           )}
 
-          <div className="flex items-center gap-2 mr-auto">
-            {/* Edit */}
-            <motion.button
-              whileTap={{ scale: 0.92 }}
-              onClick={() => onEdit(item)}
-              className={cn(
-                'w-9 h-9 rounded-xl flex items-center justify-center',
-                'bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600',
-                'text-gray-500 hover:text-blue-600 hover:border-blue-300 hover:bg-blue-50',
-                'transition-all duration-150'
-              )}
-              aria-label={t('card.editAria')}
-            >
-              <Pencil className="w-3.5 h-3.5" strokeWidth={2.5} />
-            </motion.button>
+          {/* Spacer */}
+          <div className="flex-1" />
 
-            {/* Delete / Confirm */}
-            <AnimatePresence mode="wait">
-              {confirmDelete ? (
-                <motion.button
-                  key="confirm"
-                  initial={{ scale: 0.8, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0.8, opacity: 0 }}
-                  whileTap={{ scale: 0.92 }}
-                  onClick={handleDeleteClick}
-                  disabled={isDeleting}
-                  className={cn(
-                    'px-3 h-9 rounded-xl flex items-center gap-1.5',
-                    'bg-red-500 border border-red-400',
-                    'text-white text-xs font-bold',
-                    'min-h-[36px] transition-all'
-                  )}
-                >
-                  <Trash2 className="w-3.5 h-3.5" strokeWidth={2.5} />
-                  {t('card.confirmDelete')}
-                </motion.button>
-              ) : (
-                <motion.button
-                  key="trash"
-                  initial={{ scale: 0.8, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0.8, opacity: 0 }}
-                  whileTap={{ scale: 0.92 }}
-                  onClick={handleDeleteClick}
-                  className={cn(
-                    'w-9 h-9 rounded-xl flex items-center justify-center',
-                    'bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600',
-                    'text-gray-500 hover:text-red-600 hover:border-red-300 hover:bg-red-50',
-                    'transition-all duration-150'
-                  )}
-                  aria-label={t('card.deleteAria')}
-                >
-                  <Trash2 className="w-3.5 h-3.5" strokeWidth={2.5} />
-                </motion.button>
-              )}
-            </AnimatePresence>
-          </div>
+          {/* Edit */}
+          <motion.button
+            whileTap={{ scale: 0.9 }}
+            onClick={() => onEdit(item)}
+            className={cn(
+              'w-8 h-8 rounded-xl flex items-center justify-center',
+              'bg-white/90 dark:bg-gray-700/80 border border-gray-200 dark:border-gray-600',
+              'text-gray-400 hover:text-blue-500 hover:border-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20',
+              'transition-all duration-150'
+            )}
+            aria-label={t('card.editAria')}
+          >
+            <Pencil className="w-3.5 h-3.5" strokeWidth={2.5} />
+          </motion.button>
+
+          {/* Delete / Confirm */}
+          <AnimatePresence mode="wait">
+            {confirmDelete ? (
+              <motion.button
+                key="confirm"
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.8, opacity: 0 }}
+                whileTap={{ scale: 0.92 }}
+                onClick={handleDeleteClick}
+                disabled={isDeleting}
+                className="px-3 h-8 rounded-xl flex items-center gap-1.5 bg-red-500 text-white text-xs font-bold shadow-sm shadow-red-400/30 disabled:opacity-60"
+              >
+                <Trash2 className="w-3 h-3" strokeWidth={2.5} />
+                {t('card.confirmDelete')}
+              </motion.button>
+            ) : (
+              <motion.button
+                key="trash"
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.8, opacity: 0 }}
+                whileTap={{ scale: 0.9 }}
+                onClick={handleDeleteClick}
+                className={cn(
+                  'w-8 h-8 rounded-xl flex items-center justify-center',
+                  'bg-white/90 dark:bg-gray-700/80 border border-gray-200 dark:border-gray-600',
+                  'text-gray-400 hover:text-red-500 hover:border-red-300 hover:bg-red-50 dark:hover:bg-red-900/20',
+                  'transition-all duration-150'
+                )}
+                aria-label={t('card.deleteAria')}
+              >
+                <Trash2 className="w-3.5 h-3.5" strokeWidth={2.5} />
+              </motion.button>
+            )}
+          </AnimatePresence>
         </div>
       </div>
     </motion.div>

--- a/client/src/components/features/shopping/ShoppingItemCard.jsx
+++ b/client/src/components/features/shopping/ShoppingItemCard.jsx
@@ -20,7 +20,7 @@ const CAT_BG = {
 };
 
 const ShoppingItemCard = ({ item, onEdit, onDelete, onToggleBought, isDeleting }) => {
-  const { t } = useTranslation('shopping');
+  const { t, isRTL } = useTranslation('shopping');
   const [confirmDelete, setConfirmDelete] = useState(false);
   const timeoutRef = useRef(null);
 
@@ -54,10 +54,9 @@ const ShoppingItemCard = ({ item, onEdit, onDelete, onToggleBought, isDeleting }
         'transition-shadow hover:shadow-[0_4px_20px_rgba(0,0,0,0.09)]',
         cardBg
       )}
-      dir="rtl"
     >
-      {/* Right-side category accent (RTL = start side) */}
-      <div className={cn('absolute top-0 right-0 w-[3px] h-full', cat.dot)} />
+      {/* Start-side category accent (right in RTL, left in LTR) */}
+      <div className={cn('absolute top-0 w-[3px] h-full', cat.dot, isRTL ? 'right-0' : 'left-0')} />
 
       <div className="px-4 pt-4 pb-3 pr-5">
 

--- a/client/src/components/features/shopping/ShoppingShareSheet.jsx
+++ b/client/src/components/features/shopping/ShoppingShareSheet.jsx
@@ -64,13 +64,14 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
   const [respondingToken, setRespondingToken] = useState(null);
 
   const handleInvite = useCallback(async () => {
-    if (!email.trim()) { setEmailError(isRTL ? 'נדרש אימייל' : 'Email required'); return; }
+    if (!email.trim()) { setEmailError(t('share.emailRequired')); return; }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
-      setEmailError(isRTL ? 'אימייל לא תקין' : 'Invalid email');
+      setEmailError(t('share.emailInvalid'));
       return;
     }
     setEmailError('');
-    await invite(email.trim());
+    const result = await invite(email.trim());
+    if (result?.success === false) return;
     setSentMsg(t('share.successMessage'));
     setEmail('');
     setTimeout(() => setSentMsg(''), 4000);
@@ -174,7 +175,7 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
         {/* ── Pending received invitations ── */}
         {pendingInvitations.length > 0 && (
           <>
-            <SectionHeader icon={Mail} label={isRTL ? 'הזמנות שקיבלת' : 'Invitations Received'} count={pendingInvitations.length} color="text-blue-500" />
+            <SectionHeader icon={Mail} label={t('share.receivedLabel')} count={pendingInvitations.length} color="text-blue-500" />
             <div className="flex flex-col gap-3">
               {pendingInvitations.map((inv, idx) => {
                 const name = inv.inviter_first_name
@@ -193,7 +194,7 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
                     <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
                       <p className="text-sm font-bold text-gray-800 dark:text-white truncate">{name}</p>
                       <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                        {isRTL ? 'הזמין אותך לרשימת קניות' : 'Invited you to a shopping list'}
+                        {t('share.invitedYou')}
                       </p>
                     </div>
                     <div className="flex gap-2">
@@ -201,13 +202,13 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
                         onClick={() => handleRespond(inv.token, 'accept')}
                         className="h-9 px-3 rounded-xl flex items-center gap-1.5 bg-emerald-500 text-white text-xs font-bold shadow-sm disabled:opacity-50">
                         {busy ? <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" /> : <Check className="w-3.5 h-3.5" strokeWidth={2.5} />}
-                        {isRTL ? 'אישור' : 'Accept'}
+                        {t('share.accept')}
                       </motion.button>
                       <motion.button whileTap={{ scale: 0.9 }} disabled={busy}
                         onClick={() => handleRespond(inv.token, 'decline')}
                         className="h-9 px-3 rounded-xl flex items-center gap-1.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs font-bold">
                         <X className="w-3.5 h-3.5" strokeWidth={2.5} />
-                        {isRTL ? 'דחייה' : 'Decline'}
+                        {t('share.decline')}
                       </motion.button>
                     </div>
                   </motion.div>
@@ -241,7 +242,7 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
                     'text-emerald-600 bg-emerald-50 border-emerald-200',
                     'dark:text-emerald-400 dark:bg-emerald-900/20 dark:border-emerald-800'
                   )}>
-                    {isRTL ? 'חבר' : 'Member'}
+                    {t('share.memberBadge')}
                   </span>
                   <motion.button whileTap={{ scale: 0.9 }}
                     onClick={() => removeMember(m.member_id ?? m.id)}
@@ -261,7 +262,7 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
         {/* ── Lists shared with me ── */}
         {sharedWithMe.length > 0 && (
           <>
-            <SectionHeader icon={UserCheck} label={isRTL ? 'רשימות שמשותפות איתי' : 'Shared With Me'} count={sharedWithMe.length} color="text-emerald-500" />
+            <SectionHeader icon={UserCheck} label={t('share.sharedWithMeLabel')} count={sharedWithMe.length} color="text-emerald-500" />
             <div className="flex flex-col gap-3">
               {sharedWithMe.map((m, idx) => (
                 <motion.div key={m.owner_id ?? m.id}
@@ -318,7 +319,7 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
                   <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
                     <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 truncate" dir="ltr">{inv.invitee_email}</p>
                     <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
-                      {isRTL ? 'ממתין לאישור' : 'Awaiting response'}
+                      {t('share.awaitingResponse')}
                     </p>
                   </div>
                   <motion.button whileTap={{ scale: 0.9 }}
@@ -347,10 +348,10 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
               <Users className="w-10 h-10 text-blue-400" strokeWidth={1.5} />
             </div>
             <p className="text-base font-bold text-gray-700 dark:text-gray-300 mb-1">
-              {isRTL ? 'עדיין לא שיתפת את הרשימה' : "You haven't shared the list yet"}
+              {t('share.emptyTitle')}
             </p>
             <p className="text-sm text-gray-400 dark:text-gray-500 max-w-xs">
-              {isRTL ? 'הזמן חברים להצטרף ולשתף ברשימה שלך' : 'Invite friends to join and share your list'}
+              {t('share.emptyDescription')}
             </p>
           </div>
         )}

--- a/client/src/components/features/shopping/ShoppingShareSheet.jsx
+++ b/client/src/components/features/shopping/ShoppingShareSheet.jsx
@@ -1,44 +1,57 @@
 /**
- * ShoppingShareSheet — manage sharing for the shopping list
+ * ShoppingShareSheet — manage list sharing
  */
 
 import React, { useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   UserPlus, Users, Mail, Check, X, Clock,
-  Trash2, LogOut, Send, UserCheck,
+  Trash2, LogOut, Send, UserCheck, Crown,
 } from 'lucide-react';
 import { cn } from '../../../utils/helpers';
 import { useShoppingShare } from '../../../hooks/useShoppingShare';
 import { useTranslation } from '../../../stores';
 import BottomSheet from '../../common/BottomSheet';
 
-const Avatar = ({ name, size = 'md' }) => {
-  const initials = (name || '?').slice(0, 2).toUpperCase();
-  const sizes = { sm: 'w-7 h-7 text-xs', md: 'w-9 h-9 text-sm' };
+const AVATAR_COLORS = [
+  'from-blue-500 to-blue-600',
+  'from-purple-500 to-purple-600',
+  'from-emerald-500 to-emerald-600',
+  'from-orange-500 to-orange-600',
+  'from-pink-500 to-pink-600',
+];
+
+const Avatar = ({ name, size = 'md', colorIdx = 0 }) => {
+  const initial = (name || '?')[0].toUpperCase();
+  const sizeMap = { sm: 'w-9 h-9 text-sm', md: 'w-11 h-11 text-base', lg: 'w-14 h-14 text-lg' };
   return (
     <div className={cn(
-      'rounded-full bg-gradient-to-br from-blue-500 to-indigo-600',
-      'flex items-center justify-center text-white font-bold flex-shrink-0',
-      sizes[size]
+      'rounded-2xl flex items-center justify-center text-white font-extrabold flex-shrink-0',
+      `bg-gradient-to-br ${AVATAR_COLORS[colorIdx % AVATAR_COLORS.length]}`,
+      'shadow-md',
+      sizeMap[size]
     )}>
-      {initials}
+      {initial}
     </div>
   );
 };
 
-const SectionLabel = ({ icon: Icon, label, count }) => (
-  <div className="flex items-center gap-2 mb-2 mt-4">
-    <Icon className="w-3.5 h-3.5 text-gray-400" strokeWidth={2} />
-    <span className="text-xs font-bold text-gray-500 uppercase tracking-wide">{label}</span>
+const SectionHeader = ({ icon: Icon, label, count, color = 'text-gray-500' }) => (
+  <div className="flex items-center gap-2 px-1 mt-6 mb-3">
+    <div className={cn('w-5 h-5 flex items-center justify-center', color)}>
+      <Icon className="w-4 h-4" strokeWidth={2} />
+    </div>
+    <span className={cn('text-xs font-bold uppercase tracking-wider', color)}>{label}</span>
     {count > 0 && (
-      <span className="text-xs font-bold text-blue-600 bg-blue-50 px-1.5 rounded-full">{count}</span>
+      <span className="ml-1 text-xs font-extrabold bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full">
+        {count}
+      </span>
     )}
   </div>
 );
 
 const ShoppingShareSheet = ({ isOpen, onClose }) => {
-  const { t } = useTranslation('shopping');
+  const { t, isRTL } = useTranslation('shopping');
   const {
     myMembers, sharedWithMe, pendingSent, pendingInvitations,
     invite, respond, removeMember, cancelInvite,
@@ -51,19 +64,17 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
   const [respondingToken, setRespondingToken] = useState(null);
 
   const handleInvite = useCallback(async () => {
-    if (!email.trim()) { setEmailError('נדרש אימייל'); return; }
+    if (!email.trim()) { setEmailError(isRTL ? 'נדרש אימייל' : 'Email required'); return; }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
-      setEmailError('אימייל לא תקין');
+      setEmailError(isRTL ? 'אימייל לא תקין' : 'Invalid email');
       return;
     }
     setEmailError('');
-    const result = await invite(email.trim());
-    if (result?.success !== false) {
-      setSentMsg(t('share.successMessage'));
-      setEmail('');
-      setTimeout(() => setSentMsg(''), 5000);
-    }
-  }, [email, invite, t]);
+    await invite(email.trim());
+    setSentMsg(t('share.successMessage'));
+    setEmail('');
+    setTimeout(() => setSentMsg(''), 4000);
+  }, [email, invite, t, isRTL]);
 
   const handleRespond = useCallback(async (token, action) => {
     setRespondingToken(token);
@@ -74,38 +85,63 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
   const displayName = (m) =>
     m.first_name ? `${m.first_name} ${m.last_name || ''}`.trim() : m.username || m.email;
 
+  const isEmpty = myMembers.length === 0 && sharedWithMe.length === 0
+    && pendingSent.length === 0 && pendingInvitations.length === 0;
+
   return (
-    <BottomSheet isOpen={isOpen} onClose={onClose} title={t('share.title')} height="auto">
-      <div className="flex flex-col gap-1 pb-8" dir="rtl">
+    <BottomSheet isOpen={isOpen} onClose={onClose} title={t('share.title')} height="full">
+      <div className="flex flex-col pb-8 gap-0">
 
-        {/* Invite input */}
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4 leading-relaxed">
-          {t('share.description')}
-        </p>
+        {/* ── Invite section ── */}
+        <div className={cn(
+          'rounded-2xl p-4 mb-2',
+          'bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20',
+          'border border-blue-100 dark:border-blue-800/40'
+        )}>
+          <p className={cn('text-sm font-medium text-gray-600 dark:text-gray-400 mb-3 leading-relaxed', isRTL ? 'text-right' : 'text-left')}>
+            {t('share.description')}
+          </p>
 
-        <div className="flex gap-2">
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => { setEmail(e.target.value); setEmailError(''); }}
-            onKeyDown={(e) => e.key === 'Enter' && handleInvite()}
-            placeholder={t('share.emailPlaceholder')}
-            dir="ltr"
-            className={cn(
-              'flex-1 rounded-2xl border bg-white/80 dark:bg-gray-800/80 px-4 py-3 text-sm font-medium',
-              'text-gray-800 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500',
-              'focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400',
-              'transition-all duration-200 shadow-[0_2px_8px_rgba(0,0,0,0.04)]',
-              'dark:border-gray-700',
-              emailError && 'border-red-400 focus:ring-red-400/40'
+          {/* Email input */}
+          <div className="relative mb-2">
+            <Mail className={cn(
+              'absolute top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none',
+              isRTL ? 'right-4' : 'left-4'
+            )} strokeWidth={2} />
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => { setEmail(e.target.value); setEmailError(''); }}
+              onKeyDown={(e) => e.key === 'Enter' && handleInvite()}
+              placeholder={t('share.emailPlaceholder')}
+              dir="ltr"
+              className={cn(
+                'w-full rounded-xl border bg-white dark:bg-gray-800 py-3.5 text-sm font-medium',
+                'text-gray-800 dark:text-gray-100 placeholder:text-gray-400',
+                'focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-blue-400',
+                'transition-all duration-200 dark:border-gray-700',
+                isRTL ? 'pr-10 pl-4' : 'pl-10 pr-4',
+                emailError && 'border-red-400 focus:ring-red-400/40'
+              )}
+            />
+          </div>
+
+          <AnimatePresence>
+            {emailError && (
+              <motion.p initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }}
+                className={cn('text-xs text-red-500 font-medium mb-2', isRTL ? 'text-right' : 'text-left')}>
+                {emailError}
+              </motion.p>
             )}
-          />
+          </AnimatePresence>
+
+          {/* Send button */}
           <motion.button
-            whileTap={{ scale: 0.93 }}
+            whileTap={{ scale: 0.97 }}
             onClick={handleInvite}
             disabled={isInviting}
             className={cn(
-              'px-4 h-12 rounded-2xl flex items-center gap-2',
+              'w-full flex items-center justify-center gap-2 py-3.5 rounded-xl',
               'bg-gradient-to-l from-blue-600 to-indigo-600 text-white font-bold text-sm',
               'shadow-md shadow-blue-500/25 transition-opacity',
               isInviting && 'opacity-60 cursor-not-allowed'
@@ -117,159 +153,205 @@ const ShoppingShareSheet = ({ isOpen, onClose }) => {
             }
             {t('share.send')}
           </motion.button>
+
+          <AnimatePresence>
+            {sentMsg && (
+              <motion.div
+                initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }}
+                className={cn(
+                  'flex items-center gap-2 mt-3 px-3 py-2.5 rounded-xl',
+                  'bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800',
+                  isRTL ? 'flex-row-reverse' : 'flex-row'
+                )}
+              >
+                <Check className="w-4 h-4 text-emerald-500 flex-shrink-0" strokeWidth={2.5} />
+                <span className="text-xs text-emerald-700 dark:text-emerald-300 font-medium">{sentMsg}</span>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
 
-        <AnimatePresence>
-          {emailError && (
-            <motion.p initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }}
-              className="text-xs text-red-500 font-medium mt-1">
-              {emailError}
-            </motion.p>
-          )}
-          {sentMsg && (
-            <motion.div initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }}
-              className="flex items-center gap-2 mt-2 px-3 py-2.5 rounded-xl bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800">
-              <Check className="w-4 h-4 text-emerald-500 flex-shrink-0" strokeWidth={2.5} />
-              <span className="text-xs text-emerald-700 dark:text-emerald-300 font-medium">{sentMsg}</span>
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        {/* Pending received invitations */}
+        {/* ── Pending received invitations ── */}
         {pendingInvitations.length > 0 && (
           <>
-            <SectionLabel icon={Mail} label="הזמנות שקיבלת" count={pendingInvitations.length} />
-            <div className="flex flex-col gap-2">
-              {pendingInvitations.map((inv) => {
+            <SectionHeader icon={Mail} label={isRTL ? 'הזמנות שקיבלת' : 'Invitations Received'} count={pendingInvitations.length} color="text-blue-500" />
+            <div className="flex flex-col gap-3">
+              {pendingInvitations.map((inv, idx) => {
                 const name = inv.inviter_first_name
                   ? `${inv.inviter_first_name} ${inv.inviter_last_name || ''}`.trim()
                   : inv.inviter_username;
                 const busy = respondingToken === inv.token && isResponding;
                 return (
-                  <div key={inv.id} className={cn(
-                    'flex items-center gap-3 px-3 py-3 rounded-2xl',
-                    'bg-blue-50/80 dark:bg-blue-900/20 border border-blue-100 dark:border-blue-800'
-                  )}>
-                    <Avatar name={name} />
-                    <div className="flex-1 min-w-0">
+                  <motion.div key={inv.id}
+                    initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
+                    className={cn(
+                      'flex items-center gap-4 px-4 py-4 rounded-2xl',
+                      'bg-blue-50/80 dark:bg-blue-900/15 border border-blue-200/60 dark:border-blue-800/40'
+                    )}
+                  >
+                    <Avatar name={name} size="md" colorIdx={idx} />
+                    <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
                       <p className="text-sm font-bold text-gray-800 dark:text-white truncate">{name}</p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">הזמין אותך לרשימת קניות</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                        {isRTL ? 'הזמין אותך לרשימת קניות' : 'Invited you to a shopping list'}
+                      </p>
                     </div>
-                    <div className="flex gap-1.5">
+                    <div className="flex gap-2">
                       <motion.button whileTap={{ scale: 0.9 }} disabled={busy}
                         onClick={() => handleRespond(inv.token, 'accept')}
-                        className="w-8 h-8 rounded-xl flex items-center justify-center bg-emerald-500 text-white shadow-sm disabled:opacity-50">
+                        className="h-9 px-3 rounded-xl flex items-center gap-1.5 bg-emerald-500 text-white text-xs font-bold shadow-sm disabled:opacity-50">
                         {busy ? <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" /> : <Check className="w-3.5 h-3.5" strokeWidth={2.5} />}
+                        {isRTL ? 'אישור' : 'Accept'}
                       </motion.button>
                       <motion.button whileTap={{ scale: 0.9 }} disabled={busy}
                         onClick={() => handleRespond(inv.token, 'decline')}
-                        className="w-8 h-8 rounded-xl flex items-center justify-center bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+                        className="h-9 px-3 rounded-xl flex items-center gap-1.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs font-bold">
                         <X className="w-3.5 h-3.5" strokeWidth={2.5} />
+                        {isRTL ? 'דחייה' : 'Decline'}
                       </motion.button>
                     </div>
-                  </div>
+                  </motion.div>
                 );
               })}
             </div>
           </>
         )}
 
-        {/* People sharing my list */}
+        {/* ── People I share my list with ── */}
         {myMembers.length > 0 && (
           <>
-            <SectionLabel icon={Users} label={t('share.membersLabel')} count={myMembers.length} />
-            <div className="flex flex-col gap-2">
-              {myMembers.map((m) => (
-                <div key={m.member_id ?? m.id} className={cn(
-                  'flex items-center gap-3 px-3 py-3 rounded-2xl',
-                  'bg-white dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700/60',
-                  'shadow-[0_2px_8px_rgba(0,0,0,0.04)]'
-                )}>
-                  <Avatar name={displayName(m)} />
-                  <div className="flex-1 min-w-0">
+            <SectionHeader icon={Users} label={t('share.membersLabel')} count={myMembers.length} color="text-purple-500" />
+            <div className="flex flex-col gap-3">
+              {myMembers.map((m, idx) => (
+                <motion.div key={m.member_id ?? m.id}
+                  initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
+                  className={cn(
+                    'flex items-center gap-4 px-4 py-4 rounded-2xl',
+                    'bg-white dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700/60',
+                    'shadow-[0_2px_12px_rgba(0,0,0,0.04)]'
+                  )}
+                >
+                  <Avatar name={displayName(m)} size="md" colorIdx={idx + 1} />
+                  <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
                     <p className="text-sm font-bold text-gray-800 dark:text-white truncate">{displayName(m)}</p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{m.email}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">{m.email}</p>
                   </div>
-                  <span className="text-[10px] font-bold text-emerald-600 bg-emerald-50 dark:bg-emerald-900/20 px-2 py-0.5 rounded-full border border-emerald-200 dark:border-emerald-800 mr-1">
-                    חבר
+                  <span className={cn(
+                    'text-[11px] font-bold px-2.5 py-1 rounded-full border flex-shrink-0',
+                    'text-emerald-600 bg-emerald-50 border-emerald-200',
+                    'dark:text-emerald-400 dark:bg-emerald-900/20 dark:border-emerald-800'
+                  )}>
+                    {isRTL ? 'חבר' : 'Member'}
                   </span>
                   <motion.button whileTap={{ scale: 0.9 }}
                     onClick={() => removeMember(m.member_id ?? m.id)}
-                    className="w-8 h-8 rounded-xl flex items-center justify-center bg-gray-50 dark:bg-gray-700 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors">
-                    <Trash2 className="w-3.5 h-3.5" strokeWidth={2.5} />
+                    className={cn(
+                      'w-9 h-9 rounded-xl flex items-center justify-center',
+                      'bg-gray-50 dark:bg-gray-700 text-gray-400',
+                      'hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors'
+                    )}>
+                    <Trash2 className="w-4 h-4" strokeWidth={2} />
                   </motion.button>
-                </div>
+                </motion.div>
               ))}
             </div>
           </>
         )}
 
-        {/* Lists shared with me */}
+        {/* ── Lists shared with me ── */}
         {sharedWithMe.length > 0 && (
           <>
-            <SectionLabel icon={UserCheck} label="רשימות שמשותפות איתי" count={sharedWithMe.length} />
-            <div className="flex flex-col gap-2">
-              {sharedWithMe.map((m) => (
-                <div key={m.owner_id ?? m.id} className={cn(
-                  'flex items-center gap-3 px-3 py-3 rounded-2xl',
-                  'bg-white dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700/60',
-                  'shadow-[0_2px_8px_rgba(0,0,0,0.04)]'
-                )}>
-                  <Avatar name={displayName(m)} />
-                  <div className="flex-1 min-w-0">
+            <SectionHeader icon={UserCheck} label={isRTL ? 'רשימות שמשותפות איתי' : 'Shared With Me'} count={sharedWithMe.length} color="text-emerald-500" />
+            <div className="flex flex-col gap-3">
+              {sharedWithMe.map((m, idx) => (
+                <motion.div key={m.owner_id ?? m.id}
+                  initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
+                  className={cn(
+                    'flex items-center gap-4 px-4 py-4 rounded-2xl',
+                    'bg-white dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700/60',
+                    'shadow-[0_2px_12px_rgba(0,0,0,0.04)]'
+                  )}
+                >
+                  <Avatar name={displayName(m)} size="md" colorIdx={idx + 2} />
+                  <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
                     <p className="text-sm font-bold text-gray-800 dark:text-white truncate">{displayName(m)}</p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{m.email}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">{m.email}</p>
                   </div>
-                  <span className="text-[10px] font-bold text-blue-600 bg-blue-50 dark:bg-blue-900/20 px-2 py-0.5 rounded-full border border-blue-200 dark:border-blue-800 mr-1">
-                    {t('share.ownerBadge')}
-                  </span>
+                  <div className={cn('flex items-center gap-1.5 flex-shrink-0 px-2.5 py-1 rounded-full border',
+                    'text-blue-600 bg-blue-50 border-blue-200',
+                    'dark:text-blue-400 dark:bg-blue-900/20 dark:border-blue-800')}>
+                    <Crown className="w-3 h-3" strokeWidth={2} />
+                    <span className="text-[11px] font-bold">{t('share.ownerBadge')}</span>
+                  </div>
                   <motion.button whileTap={{ scale: 0.9 }}
                     onClick={() => removeMember(m.owner_id ?? m.id)}
-                    className="w-8 h-8 rounded-xl flex items-center justify-center bg-gray-50 dark:bg-gray-700 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
-                    title={t('share.leave')}>
-                    <LogOut className="w-3.5 h-3.5" strokeWidth={2.5} />
+                    title={t('share.leave')}
+                    className={cn(
+                      'w-9 h-9 rounded-xl flex items-center justify-center',
+                      'bg-gray-50 dark:bg-gray-700 text-gray-400',
+                      'hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors'
+                    )}>
+                    <LogOut className="w-4 h-4" strokeWidth={2} />
                   </motion.button>
-                </div>
+                </motion.div>
               ))}
             </div>
           </>
         )}
 
-        {/* Pending invitations I sent */}
+        {/* ── Pending sent invitations ── */}
         {pendingSent.length > 0 && (
           <>
-            <SectionLabel icon={Clock} label={t('share.pendingLabel')} count={pendingSent.length} />
-            <div className="flex flex-col gap-2">
+            <SectionHeader icon={Clock} label={t('share.pendingLabel')} count={pendingSent.length} color="text-orange-400" />
+            <div className="flex flex-col gap-3">
               {pendingSent.map((inv) => (
-                <div key={inv.token} className={cn(
-                  'flex items-center gap-3 px-3 py-3 rounded-2xl',
-                  'bg-gray-50 dark:bg-gray-800/40 border border-gray-100 dark:border-gray-700/60'
-                )}>
-                  <div className="w-9 h-9 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
-                    <Clock className="w-4 h-4 text-gray-400" strokeWidth={2} />
+                <motion.div key={inv.token}
+                  initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
+                  className={cn(
+                    'flex items-center gap-4 px-4 py-4 rounded-2xl',
+                    'bg-gray-50/80 dark:bg-gray-800/40 border border-gray-100 dark:border-gray-700/60'
+                  )}
+                >
+                  <div className="w-11 h-11 rounded-2xl bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
+                    <Clock className="w-5 h-5 text-gray-400" strokeWidth={1.5} />
                   </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate dir-ltr">{inv.invitee_email}</p>
-                    <p className="text-xs text-gray-400 dark:text-gray-500">ממתין לאישור</p>
+                  <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
+                    <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 truncate" dir="ltr">{inv.invitee_email}</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
+                      {isRTL ? 'ממתין לאישור' : 'Awaiting response'}
+                    </p>
                   </div>
                   <motion.button whileTap={{ scale: 0.9 }}
                     onClick={() => cancelInvite(inv.invitee_email)}
-                    className="w-8 h-8 rounded-xl flex items-center justify-center bg-gray-100 dark:bg-gray-700 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors">
-                    <X className="w-3.5 h-3.5" strokeWidth={2.5} />
+                    className={cn(
+                      'w-9 h-9 rounded-xl flex items-center justify-center',
+                      'bg-gray-100 dark:bg-gray-700 text-gray-400',
+                      'hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors'
+                    )}>
+                    <X className="w-4 h-4" strokeWidth={2.5} />
                   </motion.button>
-                </div>
+                </motion.div>
               ))}
             </div>
           </>
         )}
 
-        {/* Empty state */}
-        {myMembers.length === 0 && sharedWithMe.length === 0 && pendingSent.length === 0 && pendingInvitations.length === 0 && (
-          <div className="flex flex-col items-center py-8 text-center">
-            <div className="w-16 h-16 rounded-2xl bg-blue-50 dark:bg-blue-900/20 flex items-center justify-center mb-4">
-              <Users className="w-8 h-8 text-blue-400" strokeWidth={1.5} />
+        {/* ── Empty state ── */}
+        {isEmpty && (
+          <div className="flex flex-col items-center py-12 text-center">
+            <div className={cn(
+              'w-20 h-20 rounded-3xl flex items-center justify-center mb-5',
+              'bg-gradient-to-br from-blue-100 to-indigo-100 dark:from-blue-900/30 dark:to-indigo-900/30',
+              'shadow-[0_8px_24px_rgba(99,102,241,0.12)]'
+            )}>
+              <Users className="w-10 h-10 text-blue-400" strokeWidth={1.5} />
             </div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">עדיין לא שיתפת את הרשימה</p>
+            <p className="text-base font-bold text-gray-700 dark:text-gray-300 mb-1">
+              {isRTL ? 'עדיין לא שיתפת את הרשימה' : "You haven't shared the list yet"}
+            </p>
+            <p className="text-sm text-gray-400 dark:text-gray-500 max-w-xs">
+              {isRTL ? 'הזמן חברים להצטרף ולשתף ברשימה שלך' : 'Invite friends to join and share your list'}
+            </p>
           </div>
         )}
 

--- a/client/src/hooks/useShoppingItems.js
+++ b/client/src/hooks/useShoppingItems.js
@@ -6,11 +6,13 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api';
 import useAuthStore from '../stores/authStore';
 import { useToast } from './useToast';
+import { useTranslation } from '../stores';
 
 export function useShoppingItems() {
   const queryClient = useQueryClient();
   const toast = useToast();
   const userId = useAuthStore((s) => s.user?.id);
+  const { t } = useTranslation('shopping');
 
   // Must match the ITEMS_KEY used in useShoppingShare so cache
   // invalidation after accept/decline/remove propagates to this query.
@@ -21,7 +23,7 @@ export function useShoppingItems() {
     enabled: !!userId,
     queryFn: async () => {
       const result = await api.shopping.getAll();
-      if (!result.success) throw new Error(result.error?.message || 'Failed to fetch shopping list');
+      if (!result.success) throw new Error(result.error?.message || t('toasts.fetchError'));
       return result.data; // { items, total }
     },
     staleTime: 0,              // always stale — fetch fresh from DB every mount
@@ -35,38 +37,38 @@ export function useShoppingItems() {
   const createMutation = useMutation({
     mutationFn: async (data) => {
       const result = await api.shopping.create(data);
-      if (!result.success) throw new Error(result.error?.message || 'שגיאה בהוספת פריט');
+      if (!result.success) throw new Error(result.error?.message || t('toasts.createError'));
       return result.data;
     },
-    onSuccess: () => { invalidate(); toast.success('הפריט נוסף לרשימה'); },
-    onError: (err) => toast.error(err.message || 'שגיאה בהוספת פריט'),
+    onSuccess: () => { invalidate(); toast.success(t('toasts.createSuccess')); },
+    onError: (err) => toast.error(err.message || t('toasts.createError')),
   });
 
   const updateMutation = useMutation({
     mutationFn: async ({ id, data }) => {
       const result = await api.shopping.update(id, data);
-      if (!result.success) throw new Error(result.error?.message || 'שגיאה בעדכון פריט');
+      if (!result.success) throw new Error(result.error?.message || t('toasts.updateError'));
       return result.data;
     },
-    onSuccess: () => { invalidate(); toast.success('הפריט עודכן'); },
-    onError: (err) => toast.error(err.message || 'שגיאה בעדכון פריט'),
+    onSuccess: () => { invalidate(); toast.success(t('toasts.updateSuccess')); },
+    onError: (err) => toast.error(err.message || t('toasts.updateError')),
   });
 
   const deleteMutation = useMutation({
     mutationFn: async (id) => {
       const result = await api.shopping.remove(id);
-      if (!result.success) throw new Error(result.error?.message || 'שגיאה במחיקת פריט');
+      if (!result.success) throw new Error(result.error?.message || t('toasts.deleteError'));
       return result;
     },
-    onSuccess: () => { invalidate(); toast.success('הפריט נמחק'); },
-    onError: (err) => toast.error(err.message || 'שגיאה במחיקת פריט'),
+    onSuccess: () => { invalidate(); toast.success(t('toasts.deleteSuccess')); },
+    onError: (err) => toast.error(err.message || t('toasts.deleteError')),
   });
 
   // Quiet mutation for optimistic toggle — no toasts, one retry for cold-start servers
   const toggleMutation = useMutation({
     mutationFn: async ({ id, data }) => {
       const result = await api.shopping.update(id, data);
-      if (!result.success) throw new Error(result.error?.message || 'שגיאה בעדכון פריט');
+      if (!result.success) throw new Error(result.error?.message || t('toasts.updateError'));
       return result.data;
     },
     retry: 1,
@@ -86,7 +88,7 @@ export function useShoppingItems() {
         if (!old) return old;
         return { ...old, items: old.items.map((i) => i.id === item.id ? { ...i, is_bought: item.is_bought } : i) };
       });
-      toast.error('שגיאה בעדכון פריט');
+      toast.error(t('toasts.updateError'));
     });
   };
 

--- a/client/src/hooks/useShoppingItems.js
+++ b/client/src/hooks/useShoppingItems.js
@@ -4,16 +4,21 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api';
+import useAuthStore from '../stores/authStore';
 import { useToast } from './useToast';
-
-const QUERY_KEY = ['shopping-items'];
 
 export function useShoppingItems() {
   const queryClient = useQueryClient();
   const toast = useToast();
+  const userId = useAuthStore((s) => s.user?.id);
+
+  // Must match the ITEMS_KEY used in useShoppingShare so cache
+  // invalidation after accept/decline/remove propagates to this query.
+  const QUERY_KEY = ['shopping-items', userId];
 
   const query = useQuery({
     queryKey: QUERY_KEY,
+    enabled: !!userId,
     queryFn: async () => {
       const result = await api.shopping.getAll();
       if (!result.success) throw new Error(result.error?.message || 'Failed to fetch shopping list');

--- a/client/src/hooks/useShoppingItems.js
+++ b/client/src/hooks/useShoppingItems.js
@@ -24,41 +24,42 @@ export function useShoppingItems() {
       if (!result.success) throw new Error(result.error?.message || 'Failed to fetch shopping list');
       return result.data; // { items, total }
     },
-    staleTime: 2 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,              // always stale — fetch fresh from DB every mount
+    gcTime: 5 * 60 * 1000,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
   });
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: QUERY_KEY });
 
   const createMutation = useMutation({
-    mutationFn: (data) => api.shopping.create(data),
-    onSuccess: (result) => {
-      if (!result.success) { toast.error(result.error?.message || 'שגיאה בהוספת פריט'); return; }
-      invalidate();
-      toast.success('הפריט נוסף לרשימה');
+    mutationFn: async (data) => {
+      const result = await api.shopping.create(data);
+      if (!result.success) throw new Error(result.error?.message || 'שגיאה בהוספת פריט');
+      return result.data;
     },
-    onError: () => toast.error('שגיאה בהוספת פריט'),
+    onSuccess: () => { invalidate(); toast.success('הפריט נוסף לרשימה'); },
+    onError: (err) => toast.error(err.message || 'שגיאה בהוספת פריט'),
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }) => api.shopping.update(id, data),
-    onSuccess: (result) => {
-      if (!result.success) { toast.error(result.error?.message || 'שגיאה בעדכון פריט'); return; }
-      invalidate();
-      toast.success('הפריט עודכן');
+    mutationFn: async ({ id, data }) => {
+      const result = await api.shopping.update(id, data);
+      if (!result.success) throw new Error(result.error?.message || 'שגיאה בעדכון פריט');
+      return result.data;
     },
-    onError: () => toast.error('שגיאה בעדכון פריט'),
+    onSuccess: () => { invalidate(); toast.success('הפריט עודכן'); },
+    onError: (err) => toast.error(err.message || 'שגיאה בעדכון פריט'),
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id) => api.shopping.remove(id),
-    onSuccess: (result) => {
-      if (!result.success) { toast.error(result.error?.message || 'שגיאה במחיקת פריט'); return; }
-      invalidate();
-      toast.success('הפריט נמחק');
+    mutationFn: async (id) => {
+      const result = await api.shopping.remove(id);
+      if (!result.success) throw new Error(result.error?.message || 'שגיאה במחיקת פריט');
+      return result;
     },
-    onError: () => toast.error('שגיאה במחיקת פריט'),
+    onSuccess: () => { invalidate(); toast.success('הפריט נמחק'); },
+    onError: (err) => toast.error(err.message || 'שגיאה במחיקת פריט'),
   });
 
   // Optimistic toggle — flips locally, syncs in background, rolls back on error

--- a/client/src/hooks/useShoppingItems.js
+++ b/client/src/hooks/useShoppingItems.js
@@ -62,25 +62,31 @@ export function useShoppingItems() {
     onError: (err) => toast.error(err.message || 'שגיאה במחיקת פריט'),
   });
 
+  // Quiet mutation for optimistic toggle — no toasts, one retry for cold-start servers
+  const toggleMutation = useMutation({
+    mutationFn: async ({ id, data }) => {
+      const result = await api.shopping.update(id, data);
+      if (!result.success) throw new Error(result.error?.message || 'שגיאה בעדכון פריט');
+      return result.data;
+    },
+    retry: 1,
+    onSuccess: () => invalidate(),
+  });
+
   // Optimistic toggle — flips locally, syncs in background, rolls back on error
   const toggleBought = (item) => {
-    const optimisticData = { is_bought: !item.is_bought };
+    const next = !item.is_bought;
     queryClient.setQueryData(QUERY_KEY, (old) => {
       if (!old) return old;
-      return {
-        ...old,
-        items: old.items.map((i) => i.id === item.id ? { ...i, ...optimisticData } : i),
-      };
+      return { ...old, items: old.items.map((i) => i.id === item.id ? { ...i, is_bought: next } : i) };
     });
-    return updateMutation.mutateAsync({ id: item.id, data: optimisticData }).catch(() => {
+    return toggleMutation.mutateAsync({ id: item.id, data: { is_bought: next } }).catch(() => {
       // Roll back on error
       queryClient.setQueryData(QUERY_KEY, (old) => {
         if (!old) return old;
-        return {
-          ...old,
-          items: old.items.map((i) => i.id === item.id ? { ...i, is_bought: item.is_bought } : i),
-        };
+        return { ...old, items: old.items.map((i) => i.id === item.id ? { ...i, is_bought: item.is_bought } : i) };
       });
+      toast.error('שגיאה בעדכון פריט');
     });
   };
 

--- a/client/src/hooks/useShoppingShare.js
+++ b/client/src/hooks/useShoppingShare.js
@@ -18,8 +18,9 @@ export function useShoppingShare() {
       if (!r.success) throw new Error('Failed to fetch members');
       return r.data; // { myMembers, sharedWithMe, pendingSent }
     },
-    staleTime: 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: 0,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
   });
 
   const invitationsQuery = useQuery({

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -8,7 +8,7 @@ import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import {
   User, Settings, Shield, Download, Camera,
   Eye, EyeOff, FileSpreadsheet, Braces, FileText,
-  X, Check, Loader2, AlertTriangle, ChevronDown
+  X, Check, Loader2, AlertTriangle, ChevronDown, LogOut
 } from 'lucide-react';
 
 import {
@@ -561,7 +561,7 @@ const HorizontalTabs = ({ active, onChange, t }) => (
   </div>
 );
 
-const SidebarTabs = ({ active, onChange, t }) => (
+const SidebarTabs = ({ active, onChange, t, onLogout, tc }) => (
   <div className="w-48 shrink-0 space-y-0.5">
     {TABS.map(tab => {
       const Icon     = tab.icon;
@@ -582,14 +582,27 @@ const SidebarTabs = ({ active, onChange, t }) => (
         </button>
       );
     })}
+    <div className="pt-3 mt-1 border-t border-gray-200 dark:border-gray-700">
+      <button
+        onClick={onLogout}
+        className={cn(
+          'w-full flex items-center gap-3 px-3.5 py-2.5 rounded-xl text-sm font-medium transition-all duration-150 text-left cursor-pointer',
+          'text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'
+        )}
+      >
+        <LogOut className="w-4 h-4 shrink-0" />
+        <span>{tc?.('common.logout') || 'Logout'}</span>
+      </button>
+    </div>
   </div>
 );
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 const Profile = () => {
-  const { user, updateProfile } = useAuth();
+  const { user, updateProfile, logout } = useAuth();
   const { t }        = useTranslation('profile');
+  const { t: tc }    = useTranslation();
   const authToasts   = useAuthToasts();
   const isMobile     = useIsMobile();
   const [activeTab, setActiveTab] = useState('personal');
@@ -629,7 +642,24 @@ const Profile = () => {
           </div>
           <HorizontalTabs active={activeTab} onChange={setActiveTab} t={t} />
         </div>
-        <div className="px-4 py-4 pb-24">{tabContent}</div>
+        <div className="px-4 py-4 pb-4">{tabContent}</div>
+
+        {/* Logout — bottom of profile page */}
+        <div className="px-4 pb-28 pt-2">
+          <button
+            onClick={() => logout(true)}
+            className={cn(
+              'w-full flex items-center justify-center gap-3 py-3.5 rounded-2xl',
+              'bg-white dark:bg-gray-800',
+              'border border-red-100 dark:border-red-900/40',
+              'text-red-600 dark:text-red-400 font-semibold text-sm',
+              'shadow-sm active:scale-[0.98] transition-all duration-150'
+            )}
+          >
+            <LogOut className="w-4 h-4" strokeWidth={2} />
+            {tc('common.logout') || 'Logout'}
+          </button>
+        </div>
       </div>
     );
   }
@@ -649,7 +679,7 @@ const Profile = () => {
         </div>
 
         <div className="flex gap-8 items-start">
-          <SidebarTabs active={activeTab} onChange={setActiveTab} t={t} />
+          <SidebarTabs active={activeTab} onChange={setActiveTab} t={t} onLogout={() => logout(true)} tc={tc} />
           <div className="flex-1 min-w-0">{tabContent}</div>
         </div>
       </div>

--- a/client/src/pages/ShoppingWishlistPage.jsx
+++ b/client/src/pages/ShoppingWishlistPage.jsx
@@ -37,6 +37,7 @@ const getShortName = (m) => {
 
 // ── Sharing banner — full-width, always visible ────────────
 const SharingBanner = ({ myMembers, sharedWithMe, onOpen, isRTL }) => {
+  const { t } = useTranslation('shopping');
   const combined = [
     ...myMembers.map((m) => ({ ...m, _type: 'mine' })),
     ...sharedWithMe.map((m) => ({ ...m, _type: 'shared' })),
@@ -70,7 +71,7 @@ const SharingBanner = ({ myMembers, sharedWithMe, onOpen, isRTL }) => {
         {/* Members list */}
         <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
           <p className="text-[11px] font-semibold text-blue-500 dark:text-blue-400 mb-1">
-            {combined.length === 1 ? (isRTL ? 'שיתוף עם' : 'Shared with') : (isRTL ? `שיתוף עם ${combined.length} אנשים` : `Shared with ${combined.length} people`)}
+            {combined.length === 1 ? t('sharingBanner.sharedWith') : t('sharingBanner.sharedWithCount', { count: combined.length })}
           </p>
           <div className={cn('flex items-center gap-2 flex-wrap', isRTL ? 'flex-row-reverse' : 'flex-row')}>
             {combined.slice(0, 4).map((m, i) => (
@@ -139,6 +140,7 @@ const EmptyState = ({ onAdd, filtered, t }) => (
 
 // ── Invitation banner ──────────────────────────────────────
 const InviteBanner = ({ invitations, onOpenShare, isRTL }) => {
+  const { t } = useTranslation('shopping');
   if (!invitations.length) return null;
   const first = invitations[0];
   const name = first.inviter_first_name
@@ -161,12 +163,12 @@ const InviteBanner = ({ invitations, onOpenShare, isRTL }) => {
       </div>
       <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
         <p className="text-sm font-bold text-blue-700 dark:text-blue-300 truncate">
-          {isRTL ? `${name} הזמין אותך לרשימה משותפת` : `${name} invited you to a shared list`}
+          {t('inviteBanner.invited', { name })}
         </p>
         <p className="text-xs text-blue-500 dark:text-blue-400">
           {invitations.length > 1
-            ? (isRTL ? `+${invitations.length - 1} הזמנות נוספות` : `+${invitations.length - 1} more invitations`)
-            : (isRTL ? 'לחץ לצפייה' : 'Tap to view')}
+            ? t('inviteBanner.moreInvitations', { count: invitations.length - 1 })
+            : t('inviteBanner.tapToView')}
         </p>
       </div>
     </motion.button>

--- a/client/src/pages/ShoppingWishlistPage.jsx
+++ b/client/src/pages/ShoppingWishlistPage.jsx
@@ -7,7 +7,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   ArrowRight, ShoppingCart, Plus, Package,
-  CheckCircle2, SlidersHorizontal, UserPlus, Bell,
+  CheckCircle2, SlidersHorizontal, UserPlus, Users,
 } from 'lucide-react';
 import { cn, currency } from '../utils/helpers';
 import { useShoppingItems } from '../hooks/useShoppingItems';
@@ -18,6 +18,90 @@ import ShoppingItemCard from '../components/features/shopping/ShoppingItemCard';
 import ShoppingShareSheet from '../components/features/shopping/ShoppingShareSheet';
 import { PageLoader } from '../components/ui/LoadingSpinner';
 import { useTranslation } from '../stores';
+
+// ── Avatar helpers ─────────────────────────────────────────
+const AVATAR_COLORS = [
+  'bg-blue-500', 'bg-purple-500', 'bg-emerald-500',
+  'bg-orange-500', 'bg-pink-500', 'bg-indigo-500',
+];
+
+const getInitial = (member) => {
+  const name = member.first_name || member.username || member.email || '?';
+  return name[0].toUpperCase();
+};
+
+const getDisplayName = (member) => {
+  if (member.first_name) {
+    return `${member.first_name}${member.last_name ? ' ' + member.last_name : ''}`.trim();
+  }
+  return member.username || member.email || '';
+};
+
+// ── Sharing strip ──────────────────────────────────────────
+const SharingStrip = ({ myMembers, sharedWithMe, onOpen }) => {
+  const combined = [
+    ...myMembers.map((m) => ({ ...m, _type: 'mine' })),
+    ...sharedWithMe.map((m) => ({ ...m, _type: 'shared' })),
+  ];
+  if (!combined.length) return null;
+
+  const visible = combined.slice(0, 5);
+  const overflow = combined.length - visible.length;
+
+  const label = combined.length === 1
+    ? getDisplayName(combined[0]).split(' ')[0]
+    : `${combined.length} אנשים`;
+
+  return (
+    <motion.button
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      exit={{ opacity: 0, height: 0 }}
+      onClick={onOpen}
+      className="w-full flex items-center gap-2.5 px-4 pb-2.5 group"
+    >
+      {/* Avatar stack */}
+      <div className="flex items-center">
+        {visible.map((m, i) => (
+          <div
+            key={m.id ?? i}
+            title={getDisplayName(m)}
+            style={{ zIndex: visible.length - i }}
+            className={cn(
+              'w-6 h-6 rounded-full flex items-center justify-center',
+              'text-white text-[10px] font-extrabold select-none',
+              'border-[1.5px] border-white dark:border-gray-900',
+              '-ml-1.5 first:ml-0',
+              AVATAR_COLORS[i % AVATAR_COLORS.length],
+              m._type === 'shared' && 'ring-1 ring-offset-0 ring-emerald-400/60'
+            )}
+          >
+            {getInitial(m)}
+          </div>
+        ))}
+        {overflow > 0 && (
+          <div className={cn(
+            'w-6 h-6 rounded-full flex items-center justify-center -ml-1.5',
+            'bg-gray-200 dark:bg-gray-700 border-[1.5px] border-white dark:border-gray-900',
+            'text-gray-500 dark:text-gray-400 text-[10px] font-extrabold'
+          )}>
+            +{overflow}
+          </div>
+        )}
+      </div>
+
+      {/* Label */}
+      <span className="text-[11px] font-semibold text-gray-400 dark:text-gray-500 group-hover:text-blue-500 transition-colors">
+        {sharedWithMe.length > 0 && myMembers.length === 0
+          ? `רשימה משותפת מ-${label}`
+          : `שיתוף עם ${label}`}
+      </span>
+
+      {/* Chevron hint */}
+      <Users className="w-3 h-3 text-gray-300 dark:text-gray-600 group-hover:text-blue-400 transition-colors mr-auto" strokeWidth={2} />
+    </motion.button>
+  );
+};
 
 // ── Empty state ────────────────────────────────────────────
 const EmptyState = ({ onAdd, filtered, t }) => (
@@ -102,8 +186,8 @@ const ShoppingWishlistPage = () => {
     isCreating, isUpdating, isDeleting,
   } = useShoppingItems();
 
-  const { pendingInvitations, respond } = useShoppingShare();
-  const { unreadCount, markAllRead }     = useNotifications();
+  const { myMembers, sharedWithMe, pendingInvitations, respond } = useShoppingShare();
+  const { unreadCount, markAllRead } = useNotifications();
 
   const [activeCategory, setActiveCategory] = useState(null);
   const [sheetOpen,    setSheetOpen]    = useState(false);
@@ -169,6 +253,7 @@ const ShoppingWishlistPage = () => {
   );
 
   const totalBadgeCount = unreadCount + pendingInvitations.length;
+  const hasSharingMembers = myMembers.length > 0 || sharedWithMe.length > 0;
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-blue-50/60 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-gray-900 flex flex-col" dir="rtl">
@@ -178,7 +263,8 @@ const ShoppingWishlistPage = () => {
         'sticky top-0 z-30 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl',
         'border-b border-gray-100 dark:border-gray-800'
       )}>
-        <div className="flex items-center gap-3 px-4 pt-4 pb-3">
+        {/* ── Title row ── */}
+        <div className="flex items-center gap-3 px-4 pt-4 pb-2">
 
           {/* Back */}
           <motion.button whileTap={{ scale: 0.92 }}
@@ -246,7 +332,18 @@ const ShoppingWishlistPage = () => {
           </motion.button>
         </div>
 
-        {/* Category filter chips */}
+        {/* ── Sharing strip ── */}
+        <AnimatePresence>
+          {hasSharingMembers && (
+            <SharingStrip
+              myMembers={myMembers}
+              sharedWithMe={sharedWithMe}
+              onOpen={openShare}
+            />
+          )}
+        </AnimatePresence>
+
+        {/* ── Category filter chips ── */}
         {items.length > 0 && categoryTabs.length > 1 && (
           <div className="flex gap-2 overflow-x-auto px-4 pb-3 scrollbar-none">
             {categoryTabs.map((cat) => {
@@ -266,7 +363,7 @@ const ShoppingWishlistPage = () => {
                       : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-blue-300'
                   )}
                 >
-                  {catObj && !active && <span className={cn('w-1.5 h-1.5 rounded-full flex-shrink-0', catObj.dot)} />}
+                  {catObj && <span className={cn('text-sm leading-none', !active && 'grayscale opacity-50')}>{catObj.emoji}</span>}
                   {label}
                   {active && (
                     <span className="bg-white/30 text-white text-[10px] font-extrabold px-1.5 rounded-full">{count}</span>

--- a/client/src/pages/ShoppingWishlistPage.jsx
+++ b/client/src/pages/ShoppingWishlistPage.jsx
@@ -6,8 +6,8 @@ import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  ArrowRight, ShoppingCart, Plus, Package,
-  CheckCircle2, SlidersHorizontal, UserPlus, Users,
+  ArrowRight, ArrowLeft, ShoppingCart, Plus, Package,
+  CheckCircle2, SlidersHorizontal, UserPlus, Users, ChevronLeft, ChevronRight,
 } from 'lucide-react';
 import { cn, currency } from '../utils/helpers';
 import { useShoppingItems } from '../hooks/useShoppingItems';
@@ -19,87 +19,84 @@ import ShoppingShareSheet from '../components/features/shopping/ShoppingShareShe
 import { PageLoader } from '../components/ui/LoadingSpinner';
 import { useTranslation } from '../stores';
 
-// ── Avatar helpers ─────────────────────────────────────────
 const AVATAR_COLORS = [
   'bg-blue-500', 'bg-purple-500', 'bg-emerald-500',
   'bg-orange-500', 'bg-pink-500', 'bg-indigo-500',
 ];
 
-const getInitial = (member) => {
-  const name = member.first_name || member.username || member.email || '?';
+const getInitial = (m) => {
+  const name = m.first_name || m.username || m.email || '?';
   return name[0].toUpperCase();
 };
 
-const getDisplayName = (member) => {
-  if (member.first_name) {
-    return `${member.first_name}${member.last_name ? ' ' + member.last_name : ''}`.trim();
-  }
-  return member.username || member.email || '';
+const getShortName = (m) => {
+  if (m.first_name) return m.first_name;
+  const email = m.username || m.email || '';
+  return email.split('@')[0];
 };
 
-// ── Sharing strip ──────────────────────────────────────────
-const SharingStrip = ({ myMembers, sharedWithMe, onOpen }) => {
+// ── Sharing banner — full-width, always visible ────────────
+const SharingBanner = ({ myMembers, sharedWithMe, onOpen, isRTL }) => {
   const combined = [
     ...myMembers.map((m) => ({ ...m, _type: 'mine' })),
     ...sharedWithMe.map((m) => ({ ...m, _type: 'shared' })),
   ];
   if (!combined.length) return null;
 
-  const visible = combined.slice(0, 5);
-  const overflow = combined.length - visible.length;
-
-  const label = combined.length === 1
-    ? getDisplayName(combined[0]).split(' ')[0]
-    : `${combined.length} אנשים`;
+  const BackChevron = isRTL ? ChevronLeft : ChevronRight;
 
   return (
-    <motion.button
-      initial={{ opacity: 0, height: 0 }}
-      animate={{ opacity: 1, height: 'auto' }}
-      exit={{ opacity: 0, height: 0 }}
-      onClick={onOpen}
-      className="w-full flex items-center gap-2.5 px-4 pb-2.5 group"
+    <motion.div
+      initial={{ opacity: 0, y: -6 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="px-4 pb-2"
     >
-      {/* Avatar stack */}
-      <div className="flex items-center">
-        {visible.map((m, i) => (
-          <div
-            key={m.id ?? i}
-            title={getDisplayName(m)}
-            style={{ zIndex: visible.length - i }}
-            className={cn(
-              'w-6 h-6 rounded-full flex items-center justify-center',
-              'text-white text-[10px] font-extrabold select-none',
-              'border-[1.5px] border-white dark:border-gray-900',
-              '-ml-1.5 first:ml-0',
-              AVATAR_COLORS[i % AVATAR_COLORS.length],
-              m._type === 'shared' && 'ring-1 ring-offset-0 ring-emerald-400/60'
-            )}
-          >
-            {getInitial(m)}
-          </div>
-        ))}
-        {overflow > 0 && (
-          <div className={cn(
-            'w-6 h-6 rounded-full flex items-center justify-center -ml-1.5',
-            'bg-gray-200 dark:bg-gray-700 border-[1.5px] border-white dark:border-gray-900',
-            'text-gray-500 dark:text-gray-400 text-[10px] font-extrabold'
-          )}>
-            +{overflow}
-          </div>
+      <button
+        onClick={onOpen}
+        className={cn(
+          'w-full flex items-center gap-3 px-4 py-3 rounded-2xl',
+          'bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20',
+          'border border-blue-100 dark:border-blue-800/50',
+          'hover:from-blue-100 hover:to-indigo-100 dark:hover:from-blue-900/30 dark:hover:to-indigo-900/30',
+          'transition-all duration-150',
+          isRTL ? 'flex-row-reverse' : 'flex-row'
         )}
-      </div>
+      >
+        {/* Icon */}
+        <div className="w-8 h-8 rounded-xl bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center flex-shrink-0">
+          <Users className="w-4 h-4 text-blue-500" strokeWidth={2} />
+        </div>
 
-      {/* Label */}
-      <span className="text-[11px] font-semibold text-gray-400 dark:text-gray-500 group-hover:text-blue-500 transition-colors">
-        {sharedWithMe.length > 0 && myMembers.length === 0
-          ? `רשימה משותפת מ-${label}`
-          : `שיתוף עם ${label}`}
-      </span>
+        {/* Members list */}
+        <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
+          <p className="text-[11px] font-semibold text-blue-500 dark:text-blue-400 mb-1">
+            {combined.length === 1 ? (isRTL ? 'שיתוף עם' : 'Shared with') : (isRTL ? `שיתוף עם ${combined.length} אנשים` : `Shared with ${combined.length} people`)}
+          </p>
+          <div className={cn('flex items-center gap-2 flex-wrap', isRTL ? 'flex-row-reverse' : 'flex-row')}>
+            {combined.slice(0, 4).map((m, i) => (
+              <div key={m.id ?? i} className="flex items-center gap-1.5">
+                <div className={cn(
+                  'w-5 h-5 rounded-full flex items-center justify-center text-white text-[10px] font-extrabold flex-shrink-0',
+                  AVATAR_COLORS[i % AVATAR_COLORS.length],
+                  m._type === 'shared' && 'ring-1 ring-emerald-400'
+                )}>
+                  {getInitial(m)}
+                </div>
+                <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+                  {getShortName(m)}
+                </span>
+              </div>
+            ))}
+            {combined.length > 4 && (
+              <span className="text-xs text-gray-400 font-medium">+{combined.length - 4}</span>
+            )}
+          </div>
+        </div>
 
-      {/* Chevron hint */}
-      <Users className="w-3 h-3 text-gray-300 dark:text-gray-600 group-hover:text-blue-400 transition-colors mr-auto" strokeWidth={2} />
-    </motion.button>
+        {/* Manage arrow */}
+        <BackChevron className="w-4 h-4 text-blue-400 flex-shrink-0" strokeWidth={2.5} />
+      </button>
+    </motion.div>
   );
 };
 
@@ -112,7 +109,7 @@ const EmptyState = ({ onAdd, filtered, t }) => (
     <div className={cn(
       'w-24 h-24 rounded-3xl flex items-center justify-center mb-6',
       'bg-gradient-to-br from-blue-100 to-indigo-100 dark:from-blue-900/30 dark:to-indigo-900/30',
-      'shadow-[0_8px_32px_rgba(99,102,241,0.15),inset_0_1px_0_rgba(255,255,255,0.8)]',
+      'shadow-[0_8px_32px_rgba(99,102,241,0.15)]',
       'border border-blue-100 dark:border-blue-800'
     )}>
       {filtered
@@ -141,7 +138,7 @@ const EmptyState = ({ onAdd, filtered, t }) => (
 );
 
 // ── Invitation banner ──────────────────────────────────────
-const InviteBanner = ({ invitations, onOpenShare }) => {
+const InviteBanner = ({ invitations, onOpenShare, isRTL }) => {
   if (!invitations.length) return null;
   const first = invitations[0];
   const name = first.inviter_first_name
@@ -152,21 +149,24 @@ const InviteBanner = ({ invitations, onOpenShare }) => {
       initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }}
       onClick={onOpenShare}
       className={cn(
-        'w-full flex items-center gap-3 px-4 py-3 rounded-2xl mb-4',
+        'w-full flex items-center gap-3 px-4 py-3 rounded-2xl mb-3',
         'bg-gradient-to-l from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20',
         'border border-blue-200 dark:border-blue-800',
-        'shadow-[0_2px_12px_rgba(99,102,241,0.1)]'
+        'shadow-[0_2px_12px_rgba(99,102,241,0.1)]',
+        isRTL ? 'flex-row-reverse' : 'flex-row'
       )}
     >
       <div className="w-9 h-9 rounded-full bg-blue-500/10 flex items-center justify-center flex-shrink-0">
         <UserPlus className="w-4 h-4 text-blue-500" strokeWidth={2} />
       </div>
-      <div className="flex-1 text-right min-w-0">
+      <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
         <p className="text-sm font-bold text-blue-700 dark:text-blue-300 truncate">
-          {name} הזמין אותך לרשימה משותפת
+          {isRTL ? `${name} הזמין אותך לרשימה משותפת` : `${name} invited you to a shared list`}
         </p>
         <p className="text-xs text-blue-500 dark:text-blue-400">
-          {invitations.length > 1 ? `+${invitations.length - 1} הזמנות נוספות` : 'לחץ לצפייה'}
+          {invitations.length > 1
+            ? (isRTL ? `+${invitations.length - 1} הזמנות נוספות` : `+${invitations.length - 1} more invitations`)
+            : (isRTL ? 'לחץ לצפייה' : 'Tap to view')}
         </p>
       </div>
     </motion.button>
@@ -177,8 +177,10 @@ const InviteBanner = ({ invitations, onOpenShare }) => {
 const ShoppingWishlistPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { t }  = useTranslation('shopping');
+  const { t, isRTL } = useTranslation('shopping');
   const { t: tc } = useTranslation('common');
+
+  const BackIcon = isRTL ? ArrowRight : ArrowLeft;
 
   const {
     items, isLoading, isError, refetch,
@@ -190,11 +192,10 @@ const ShoppingWishlistPage = () => {
   const { unreadCount, markAllRead } = useNotifications();
 
   const [activeCategory, setActiveCategory] = useState(null);
-  const [sheetOpen,    setSheetOpen]    = useState(false);
-  const [shareOpen,    setShareOpen]    = useState(false);
-  const [editingItem,  setEditingItem]  = useState(null);
+  const [sheetOpen,   setSheetOpen]   = useState(false);
+  const [shareOpen,   setShareOpen]   = useState(false);
+  const [editingItem, setEditingItem] = useState(null);
 
-  // Handle ?invite=TOKEN deep-link from email
   useEffect(() => {
     const token = searchParams.get('invite');
     if (token) {
@@ -209,7 +210,7 @@ const ShoppingWishlistPage = () => {
   const { categoryTabs, categoryCounts, filteredItems, unbought, bought, pendingTotal } = useMemo(() => {
     const counts = {};
     items.forEach((i) => { counts[i.category] = (counts[i.category] || 0) + 1; });
-    const tabs    = [null, ...CATEGORIES.filter((c) => counts[c.value]).map((c) => c.value)];
+    const tabs     = [null, ...CATEGORIES.filter((c) => counts[c.value]).map((c) => c.value)];
     const filtered = activeCategory === null ? items : items.filter((i) => i.category === activeCategory);
     const u = filtered.filter((i) => !i.is_bought);
     const b = filtered.filter((i) => i.is_bought);
@@ -217,17 +218,16 @@ const ShoppingWishlistPage = () => {
     return { categoryTabs: tabs, categoryCounts: counts, filteredItems: filtered, unbought: u, bought: b, pendingTotal: pending };
   }, [items, activeCategory]);
 
-  // Auto-reset category filter when filtered list becomes empty after deletion
   useEffect(() => {
     if (activeCategory !== null && filteredItems.length === 0 && items.length > 0) {
       setActiveCategory(null);
     }
   }, [activeCategory, filteredItems.length, items.length]);
 
-  const handleAdd   = useCallback(() => { setEditingItem(null); setSheetOpen(true); }, []);
-  const handleEdit  = useCallback((item) => { setEditingItem(item); setSheetOpen(true); }, []);
+  const handleAdd  = useCallback(() => { setEditingItem(null); setSheetOpen(true); }, []);
+  const handleEdit = useCallback((item) => { setEditingItem(item); setSheetOpen(true); }, []);
 
-  const handleSave  = useCallback(async (payload) => {
+  const handleSave = useCallback(async (payload) => {
     if (editingItem) await updateItem(editingItem.id, payload);
     else             await createItem(payload);
     setSheetOpen(false);
@@ -242,8 +242,8 @@ const ShoppingWishlistPage = () => {
   }, [unreadCount, markAllRead]);
 
   if (isLoading) return <PageLoader text={t('loading')} />;
-  if (isError)   return (
-    <div className="min-h-screen flex items-center justify-center p-8 text-center" dir="rtl">
+  if (isError) return (
+    <div className="min-h-screen flex items-center justify-center p-8 text-center">
       <div>
         <Package className="w-12 h-12 text-red-400 mx-auto mb-3" strokeWidth={1.5} />
         <p className="text-gray-600 dark:text-gray-400 mb-4">{t('error.title')}</p>
@@ -256,17 +256,19 @@ const ShoppingWishlistPage = () => {
   const hasSharingMembers = myMembers.length > 0 || sharedWithMe.length > 0;
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50/60 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-gray-900 flex flex-col" dir="rtl">
+    <div className="min-h-screen bg-gradient-to-b from-blue-50/60 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-gray-900 flex flex-col">
 
       {/* ── Header ── */}
       <div className={cn(
         'sticky top-0 z-30 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl',
         'border-b border-gray-100 dark:border-gray-800'
       )}>
-        {/* ── Title row ── */}
-        <div className="flex items-center gap-3 px-4 pt-4 pb-2">
 
-          {/* Back */}
+        {/* Title row */}
+        <div className={cn(
+          'flex items-center gap-3 px-4 pt-4 pb-2',
+          isRTL ? 'flex-row-reverse' : 'flex-row'
+        )}>
           <motion.button whileTap={{ scale: 0.92 }}
             onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')}
             className={cn(
@@ -276,17 +278,16 @@ const ShoppingWishlistPage = () => {
             )}
             aria-label={tc('back')}
           >
-            <ArrowRight className="w-5 h-5" strokeWidth={2} />
+            <BackIcon className="w-5 h-5" strokeWidth={2} />
           </motion.button>
 
-          <div className="flex-1 min-w-0">
+          <div className={cn('flex-1 min-w-0', isRTL ? 'text-right' : 'text-left')}>
             <h1 className="text-lg font-extrabold text-gray-900 dark:text-white leading-tight">{t('title')}</h1>
             <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
               {t('itemsCount', { count: items.length })}
             </p>
           </div>
 
-          {/* Live pending total */}
           {items.length > 0 && pendingTotal > 0 && (
             <motion.div key={pendingTotal} initial={{ scale: 0.9 }} animate={{ scale: 1 }}
               className={cn(
@@ -298,7 +299,6 @@ const ShoppingWishlistPage = () => {
             </motion.div>
           )}
 
-          {/* Share / notifications button */}
           <motion.button whileTap={{ scale: 0.92 }} onClick={openShare}
             className={cn(
               'relative w-10 h-10 rounded-2xl flex items-center justify-center flex-shrink-0',
@@ -307,19 +307,19 @@ const ShoppingWishlistPage = () => {
             )}
             aria-label={t('share.button')}
           >
-            <UserPlus className="w-4.5 h-4.5" strokeWidth={2} />
+            <UserPlus className="w-4 h-4" strokeWidth={2} />
             {totalBadgeCount > 0 && (
               <span className={cn(
-                'absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1',
+                'absolute -top-1 min-w-[18px] h-[18px] px-1',
                 'bg-red-500 text-white text-[10px] font-extrabold',
-                'rounded-full flex items-center justify-center'
+                'rounded-full flex items-center justify-center',
+                isRTL ? '-left-1' : '-right-1'
               )}>
                 {totalBadgeCount > 9 ? '9+' : totalBadgeCount}
               </span>
             )}
           </motion.button>
 
-          {/* Add item */}
           <motion.button whileTap={{ scale: 0.92 }} onClick={handleAdd}
             className={cn(
               'w-10 h-10 rounded-2xl flex items-center justify-center flex-shrink-0',
@@ -332,20 +332,24 @@ const ShoppingWishlistPage = () => {
           </motion.button>
         </div>
 
-        {/* ── Sharing strip ── */}
+        {/* Sharing banner — full-width, always visible when sharing */}
         <AnimatePresence>
           {hasSharingMembers && (
-            <SharingStrip
+            <SharingBanner
               myMembers={myMembers}
               sharedWithMe={sharedWithMe}
               onOpen={openShare}
+              isRTL={isRTL}
             />
           )}
         </AnimatePresence>
 
-        {/* ── Category filter chips ── */}
+        {/* Category filter chips */}
         {items.length > 0 && categoryTabs.length > 1 && (
-          <div className="flex gap-2 overflow-x-auto px-4 pb-3 scrollbar-none">
+          <div className={cn(
+            'flex gap-2 overflow-x-auto px-4 pb-3 scrollbar-none',
+            isRTL ? 'flex-row-reverse' : 'flex-row'
+          )}>
             {categoryTabs.map((cat) => {
               const active  = activeCategory === cat;
               const catObj  = cat !== null ? CATEGORIES.find((c) => c.value === cat) : null;
@@ -378,8 +382,7 @@ const ShoppingWishlistPage = () => {
       {/* ── Content ── */}
       <div className="flex-1 px-4 py-4 pb-28 max-w-lg mx-auto w-full">
 
-        {/* Pending invite banner */}
-        <InviteBanner invitations={pendingInvitations} onOpenShare={openShare} />
+        <InviteBanner invitations={pendingInvitations} onOpenShare={openShare} isRTL={isRTL} />
 
         {items.length === 0 ? (
           <EmptyState onAdd={handleAdd} filtered={false} t={t} />
@@ -401,7 +404,7 @@ const ShoppingWishlistPage = () => {
 
             {bought.length > 0 && (
               <motion.section key="bought" layout initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-6">
-                <div className="flex items-center gap-2 mb-3">
+                <div className={cn('flex items-center gap-2 mb-3', isRTL ? 'flex-row-reverse' : 'flex-row')}>
                   <CheckCircle2 className="w-4 h-4 text-emerald-500" strokeWidth={2} />
                   <span className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
                     {t('boughtSection', { count: bought.length })}
@@ -430,8 +433,8 @@ const ShoppingWishlistPage = () => {
           )}
           style={{ paddingBottom: 'max(env(safe-area-inset-bottom), 12px)' }}
         >
-          <div className="max-w-lg mx-auto flex items-center justify-between">
-            <div className="flex flex-col">
+          <div className={cn('max-w-lg mx-auto flex items-center', isRTL ? 'flex-row-reverse' : 'flex-row', 'justify-between')}>
+            <div className={cn('flex flex-col', isRTL ? 'items-end' : 'items-start')}>
               <span className="text-[11px] text-gray-500 dark:text-gray-400 font-medium">{t('totalPending')}</span>
               <motion.span key={pendingTotal} initial={{ scale: 0.92 }} animate={{ scale: 1 }}
                 className="text-xl font-extrabold text-gray-900 dark:text-white tabular-nums">
@@ -452,11 +455,9 @@ const ShoppingWishlistPage = () => {
         </motion.div>
       )}
 
-      {/* Add / Edit BottomSheet */}
       <ShoppingBottomSheet isOpen={sheetOpen} onClose={handleClose}
         onSave={handleSave} editItem={editingItem} isSaving={isCreating || isUpdating} />
 
-      {/* Share BottomSheet */}
       <ShoppingShareSheet isOpen={shareOpen} onClose={() => setShareOpen(false)} />
     </div>
   );

--- a/client/src/pages/admin/AdminUsers.jsx
+++ b/client/src/pages/admin/AdminUsers.jsx
@@ -56,8 +56,14 @@ const AdminUsers = () => {
     refetch 
   } = useQuery({
     queryKey: ['admin', 'users'],
-    queryFn: () => api.admin.users.getAll({}),
+    queryFn: async () => {
+      const result = await api.admin.users.getAll({});
+      if (!result.success) throw new Error(result.error?.message || 'Failed to load users');
+      return result;
+    },
     placeholderData: keepPreviousData,
+    staleTime: 0,
+    refetchOnMount: 'always',
     refetchInterval: 30000,
     refetchOnWindowFocus: true,
   });
@@ -70,76 +76,59 @@ const AdminUsers = () => {
 
   // User action mutations
   const blockUserMutation = useMutation({
-    mutationFn: (userId) => api.admin.blockUser(userId),
-    onSuccess: (data, userId) => {
+    mutationFn: async (userId) => {
+      const result = await api.admin.blockUser(userId);
+      if (!result.success) throw new Error(result.error?.message || 'Action failed');
+      return result.data;
+    },
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
-      addNotification({
-        type: 'success',
-        message: t('actions.userBlocked', { fallback: 'User blocked successfully' }),
-        duration: 3000
-      });
+      addNotification({ type: 'success', message: t('actions.userBlocked', { fallback: 'User blocked successfully' }), duration: 3000 });
       setActionLoading(null);
     },
-    onError: (error, userId) => {
-      addNotification({
-        type: 'error',
-        message: error?.response?.data?.message || t('errors.actionFailed', { fallback: 'Action failed' }),
-        duration: 4000
-      });
+    onError: (error) => {
+      addNotification({ type: 'error', message: error.message || t('errors.actionFailed', { fallback: 'Action failed' }), duration: 4000 });
       setActionLoading(null);
     }
   });
 
   const unblockUserMutation = useMutation({
-    mutationFn: (userId) => api.admin.unblockUser(userId),
-    onSuccess: (data, userId) => {
+    mutationFn: async (userId) => {
+      const result = await api.admin.unblockUser(userId);
+      if (!result.success) throw new Error(result.error?.message || 'Action failed');
+      return result.data;
+    },
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
-      addNotification({
-        type: 'success',
-        message: t('actions.userUnblocked', { fallback: 'User unblocked successfully' }),
-        duration: 3000
-      });
+      addNotification({ type: 'success', message: t('actions.userUnblocked', { fallback: 'User unblocked successfully' }), duration: 3000 });
       setActionLoading(null);
     },
-    onError: (error, userId) => {
-      addNotification({
-        type: 'error',
-        message: error?.response?.data?.message || t('errors.actionFailed', { fallback: 'Action failed' }),
-        duration: 4000
-      });
+    onError: (error) => {
+      addNotification({ type: 'error', message: error.message || t('errors.actionFailed', { fallback: 'Action failed' }), duration: 4000 });
       setActionLoading(null);
     }
   });
 
   const deleteUserMutation = useMutation({
-    mutationFn: ({ userId, reason }) => api.admin.deleteUser({ userId, reason }),
-    onSuccess: (data, variables) => {
-              // Use startTransition to prevent multiple renders
-        startTransition(() => {
-          queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
-          setActionLoading(null);
-          setShowUserModal(false);
-          setShowDeleteDialog(false);
-          setDeleteReason('');
-          setPendingDeleteUserId(null);
-        });
-      
-      addNotification({
-        type: 'success',
-        message: t('actions.userDeleted', { fallback: 'User deleted successfully' }),
-        duration: 3000
-      });
+    mutationFn: async ({ userId, reason }) => {
+      const result = await api.admin.deleteUser({ userId, reason });
+      if (!result.success) throw new Error(result.error?.message || 'Failed to delete user');
+      return result.data;
     },
-    onError: (error, variables) => {
+    onSuccess: () => {
       startTransition(() => {
+        queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
         setActionLoading(null);
+        setShowUserModal(false);
+        setShowDeleteDialog(false);
+        setDeleteReason('');
+        setPendingDeleteUserId(null);
       });
-      
-      addNotification({
-        type: 'error',
-        message: error?.response?.data?.message || t('errors.actionFailed', { fallback: 'Failed to delete user' }),
-        duration: 4000
-      });
+      addNotification({ type: 'success', message: t('actions.userDeleted', { fallback: 'User deleted successfully' }), duration: 3000 });
+    },
+    onError: (error) => {
+      startTransition(() => { setActionLoading(null); });
+      addNotification({ type: 'error', message: error.message || t('errors.actionFailed', { fallback: 'Failed to delete user' }), duration: 4000 });
     }
   });
 

--- a/client/src/translations/en/auth.js
+++ b/client/src/translations/en/auth.js
@@ -307,5 +307,10 @@ export default {
   backToEmailRequest: "Back to Email Request",
   rememberPassword: "Remember your password?",
   verificationError: "An error occurred during email verification",
-  emailVerificationComplete: "Your email has been verified successfully"
+  emailVerificationComplete: "Your email has been verified successfully",
+  verificationSentTo: "Verification email sent to",
+  verificationLinkExpiry: "The link expires in 24 hours. Check your spam folder if you don't see it.",
+  signingInWithGoogle: "Signing in with Google…",
+  registrationSuccessCheckEmail: "Account created! Please verify your email to log in.",
+  autoRedirectToLogin: "Redirecting to login in {{seconds}}s…"
 };

--- a/client/src/translations/en/shopping.js
+++ b/client/src/translations/en/shopping.js
@@ -73,20 +73,52 @@ export default {
   pendingItems: "{{count}} items pending",
   boughtItems: "{{count}} purchased",
 
+  toasts: {
+    fetchError: "Failed to load shopping list",
+    createSuccess: "Item added to list",
+    createError: "Failed to add item",
+    updateSuccess: "Item updated",
+    updateError: "Failed to update item",
+    deleteSuccess: "Item deleted",
+    deleteError: "Failed to delete item",
+  },
+
+  sharingBanner: {
+    sharedWith: "Shared with",
+    sharedWithCount: "Shared with {{count}} people",
+  },
+
+  inviteBanner: {
+    invited: "{{name}} invited you to a shared list",
+    moreInvitations: "+{{count}} more invitations",
+    tapToView: "Tap to view",
+  },
+
   share: {
     button: "Share List",
     title: "Share Shopping List",
     description: "Enter the email of the person you'd like to share with",
     emailLabel: "Email Address",
     emailPlaceholder: "friend@example.com",
+    emailRequired: "Email required",
+    emailInvalid: "Invalid email",
     send: "Send Invitation",
     sending: "Sending...",
     successMessage: "If this email is registered, an invitation has been sent",
     pendingLabel: "Pending Invitations",
+    receivedLabel: "Invitations Received",
+    invitedYou: "Invited you to a shopping list",
+    accept: "Accept",
+    decline: "Decline",
     membersLabel: "Shared With",
+    memberBadge: "Member",
+    sharedWithMeLabel: "Shared With Me",
     remove: "Remove",
     leave: "Leave Shared List",
     ownerBadge: "Owner",
     sharedBadge: "Shared",
+    awaitingResponse: "Awaiting response",
+    emptyTitle: "You haven't shared the list yet",
+    emptyDescription: "Invite friends to join and share your list",
   },
 };

--- a/client/src/translations/he/auth.js
+++ b/client/src/translations/he/auth.js
@@ -307,5 +307,10 @@ export default {
   backToEmailRequest: "חזרה לבקשת האימייל",
   rememberPassword: "זוכרים את הסיסמה?",
   verificationError: "אירעה שגיאה במהלך אימות האימייל",
-  emailVerificationComplete: "כתובת האימייל שלכם אומתה בהצלחה"
+  emailVerificationComplete: "כתובת האימייל שלכם אומתה בהצלחה",
+  verificationSentTo: "אימייל אימות נשלח לכתובת",
+  verificationLinkExpiry: "הקישור תקף ל-24 שעות. בדקו בתיקיית הספאם אם אינכם רואים את האימייל.",
+  signingInWithGoogle: "מתחבר עם Google…",
+  registrationSuccessCheckEmail: "החשבון נוצר! אנא אמתו את כתובת האימייל שלכם כדי להתחבר.",
+  autoRedirectToLogin: "מפנה להתחברות בעוד {{seconds}} שניות…"
 };

--- a/client/src/translations/he/shopping.js
+++ b/client/src/translations/he/shopping.js
@@ -73,20 +73,52 @@ export default {
   pendingItems: "{{count}} פריטים ממתינים",
   boughtItems: "{{count}} נרכשו",
 
+  toasts: {
+    fetchError: "שגיאה בטעינת הרשימה",
+    createSuccess: "הפריט נוסף לרשימה",
+    createError: "שגיאה בהוספת פריט",
+    updateSuccess: "הפריט עודכן",
+    updateError: "שגיאה בעדכון פריט",
+    deleteSuccess: "הפריט נמחק",
+    deleteError: "שגיאה במחיקת פריט",
+  },
+
+  sharingBanner: {
+    sharedWith: "שיתוף עם",
+    sharedWithCount: "שיתוף עם {{count}} אנשים",
+  },
+
+  inviteBanner: {
+    invited: "{{name}} הזמין אותך לרשימה משותפת",
+    moreInvitations: "+{{count}} הזמנות נוספות",
+    tapToView: "לחץ לצפייה",
+  },
+
   share: {
     button: "שתף רשימה",
     title: "שיתוף רשימת קניות",
     description: "הזן את האימייל של המשתמש שאיתו תרצה לשתף",
     emailLabel: "כתובת אימייל",
     emailPlaceholder: "חבר@example.com",
+    emailRequired: "נדרש אימייל",
+    emailInvalid: "אימייל לא תקין",
     send: "שלח הזמנה",
     sending: "שולח...",
     successMessage: "אם האימייל רשום במערכת, נשלחה הזמנה",
     pendingLabel: "הזמנות ממתינות",
+    receivedLabel: "הזמנות שקיבלת",
+    invitedYou: "הזמין אותך לרשימת קניות",
+    accept: "אישור",
+    decline: "דחייה",
     membersLabel: "משותף עם",
+    memberBadge: "חבר",
+    sharedWithMeLabel: "רשימות שמשותפות איתי",
     remove: "הסר",
     leave: "עזוב רשימה משותפת",
     ownerBadge: "בעלים",
     sharedBadge: "משותף",
+    awaitingResponse: "ממתין לאישור",
+    emptyTitle: "עדיין לא שיתפת את הרשימה",
+    emptyDescription: "הזמן חברים להצטרף ולשתף ברשימה שלך",
   },
 };

--- a/server/DB Migrations/09_shopping_and_notifications.sql
+++ b/server/DB Migrations/09_shopping_and_notifications.sql
@@ -1,0 +1,94 @@
+-- ✅ SpendWise — Shopping Wishlist & Notifications
+-- Creates all tables needed for the shopping wishlist feature and
+-- the in-app notification system.  Uses IF NOT EXISTS throughout so
+-- this file is safe to run multiple times (idempotent).
+
+-- Enable pgcrypto for gen_random_uuid() if not already present
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ─────────────────────────────────────────────
+-- 1. SHOPPING ITEMS
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS shopping_items (
+    id         SERIAL PRIMARY KEY,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       VARCHAR(200) NOT NULL,
+    category   VARCHAR(50)  NOT NULL DEFAULT 'אחר',
+    price_ils  DECIMAL(10,2) NOT NULL DEFAULT 0 CHECK (price_ils >= 0),
+    buy_url    TEXT,
+    notes      TEXT,
+    is_bought  BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_shopping_items_user_id
+    ON shopping_items(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_shopping_items_user_bought
+    ON shopping_items(user_id, is_bought);
+
+-- ─────────────────────────────────────────────
+-- 2. SHOPPING SHARES
+--    owner_id  = the user whose list is shared
+--    member_id = the user who can see/edit it
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS shopping_shares (
+    id         SERIAL PRIMARY KEY,
+    owner_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    member_id  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_shopping_shares UNIQUE (owner_id, member_id),
+    CONSTRAINT chk_no_self_share  CHECK (owner_id <> member_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_shopping_shares_owner  ON shopping_shares(owner_id);
+CREATE INDEX IF NOT EXISTS idx_shopping_shares_member ON shopping_shares(member_id);
+
+-- ─────────────────────────────────────────────
+-- 3. SHOPPING INVITATIONS
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS shopping_invitations (
+    id            SERIAL PRIMARY KEY,
+    inviter_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    invitee_email VARCHAR(255) NOT NULL,
+    invitee_id    INTEGER      REFERENCES users(id) ON DELETE SET NULL,
+    token         UUID NOT NULL DEFAULT gen_random_uuid(),
+    status        VARCHAR(20)  NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending','accepted','declined','cancelled')),
+    expires_at    TIMESTAMP NOT NULL DEFAULT (NOW() + INTERVAL '7 days'),
+    responded_at  TIMESTAMP,
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_shopping_invitations UNIQUE (inviter_id, invitee_email),
+    CONSTRAINT uq_shopping_invitation_token UNIQUE (token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_shopping_inv_inviter
+    ON shopping_invitations(inviter_id);
+CREATE INDEX IF NOT EXISTS idx_shopping_inv_invitee_id
+    ON shopping_invitations(invitee_id)
+    WHERE invitee_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_shopping_inv_token
+    ON shopping_invitations(token);
+CREATE INDEX IF NOT EXISTS idx_shopping_inv_status_expires
+    ON shopping_invitations(status, expires_at)
+    WHERE status = 'pending';
+
+-- ─────────────────────────────────────────────
+-- 4. NOTIFICATIONS
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS notifications (
+    id         SERIAL PRIMARY KEY,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type       VARCHAR(50)  NOT NULL,
+    title      VARCHAR(200) NOT NULL,
+    body       TEXT,
+    data       JSONB NOT NULL DEFAULT '{}',
+    is_read    BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_read
+    ON notifications(user_id, is_read);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created
+    ON notifications(user_id, created_at DESC);

--- a/server/DB Migrations/10_fix_shopping_invitation_cascade.sql
+++ b/server/DB Migrations/10_fix_shopping_invitation_cascade.sql
@@ -1,0 +1,12 @@
+-- ✅ SpendWise — Fix shopping_invitations.invitee_id FK
+-- Changes ON DELETE SET NULL → ON DELETE CASCADE so that when an invitee
+-- user is hard-deleted by an admin, their pending received invitations are
+-- also deleted instead of leaving zombie rows with invitee_id = NULL.
+
+ALTER TABLE shopping_invitations
+  DROP CONSTRAINT IF EXISTS shopping_invitations_invitee_id_fkey,
+  ADD CONSTRAINT shopping_invitations_invitee_id_fkey
+    FOREIGN KEY (invitee_id) REFERENCES users(id) ON DELETE CASCADE;
+
+-- Clean up any existing zombie rows (invitee_id = NULL from prior deletes)
+DELETE FROM shopping_invitations WHERE invitee_id IS NULL AND status = 'pending';

--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -10,6 +10,7 @@ const { asyncHandler } = require('../middleware/errorHandler');
 const { hasRole, canManageUser, clearUserCache } = require('../middleware/auth');
 const logger = require('../utils/logger');
 const errorCodes = require('../utils/errorCodes');
+const { Notification } = require('../models/ShoppingShare');
 
 class AdminController {
   /**
@@ -573,6 +574,14 @@ class AdminController {
             });
           }
 
+          // Gather members whose shared shopping list will disappear (must be done before the delete)
+          const { rows: sharedMembers } = await db.query(
+            'SELECT member_id FROM shopping_shares WHERE owner_id = $1',
+            [userId],
+            'admin_delete_get_shared_members'
+          );
+          const sharedMemberIds = sharedMembers.map(r => r.member_id);
+
           // Hard delete user and all related data in a single transaction
           const client = await db.pool.connect();
           try {
@@ -600,7 +609,11 @@ class AdminController {
             // Null out references in settings to avoid FK violations
             await client.query('UPDATE system_settings SET updated_by = NULL WHERE updated_by = $1', [userId]);
 
-            // Finally, remove the user row
+            // Explicit shopping cleanup: invitations where this user is invitee use
+            // ON DELETE CASCADE (after migration 10), but delete explicitly as belt-and-suspenders
+            await client.query('DELETE FROM shopping_invitations WHERE invitee_id = $1', [userId]);
+
+            // Finally, remove the user row (CASCADEs clean up shopping_items, shopping_shares, etc.)
             await client.query('DELETE FROM users WHERE id = $1', [userId]);
 
             await client.query('COMMIT');
@@ -609,6 +622,17 @@ class AdminController {
             throw txError;
           } finally {
             client.release();
+          }
+
+          // Notify members whose shared list was deleted along with the owner
+          for (const memberId of sharedMemberIds) {
+            Notification.create(
+              memberId,
+              'shopping_owner_deleted',
+              'רשימת קניות משותפת הוסרה',
+              'הבעלים של הרשימה המשותפת הסיר את חשבונו. הרשימה אינה זמינה יותר.',
+              {}
+            ).catch(() => {});
           }
 
           result = { action: 'deleted', userId };

--- a/server/controllers/shoppingShareController.js
+++ b/server/controllers/shoppingShareController.js
@@ -96,10 +96,24 @@ const shoppingShareController = {
     const targetId = parseInt(req.params.userId, 10);
     if (isNaN(targetId)) return res.status(400).json({ success: false, error: { message: 'מזהה לא תקין' } });
 
-    const removed = await ShoppingShare.removeMember(req.user.id, targetId)
-      || await ShoppingShare.leaveShare(targetId, req.user.id);
+    // Try owner-removes-member first, then member-leaves-voluntarily
+    const ownerRemoved = await ShoppingShare.removeMember(req.user.id, targetId);
+    const memberLeft = ownerRemoved ? false : await ShoppingShare.leaveShare(targetId, req.user.id);
 
-    if (!removed) return res.status(404).json({ success: false, error: { message: 'שיתוף לא נמצא' } });
+    if (!ownerRemoved && !memberLeft) return res.status(404).json({ success: false, error: { message: 'שיתוף לא נמצא' } });
+
+    // Notify the removed member (not when they leave voluntarily)
+    if (ownerRemoved) {
+      const removerName = req.user.first_name || req.user.username;
+      Notification.create(
+        targetId,
+        'shopping_removed',
+        'הוסרת מרשימת קניות',
+        `${removerName} הסיר אותך מרשימת הקניות המשותפת`,
+        { removedBy: req.user.id, removerName }
+      ).catch(() => {});
+    }
+
     res.json({ success: true });
   }),
 


### PR DESCRIPTION
## Summary

### Shopping Feature — Bug Fixes & UX
- **Cache staleness**: `staleTime: 0` + `refetchOnMount/WindowFocus: true` on all shopping queries — data always fresh from DB on page mount
- **Silent mutation failures**: `mutationFn` now throws `new Error` on `!result.success` so TanStack routes `onSuccess`/`onError` correctly
- **Double toast on toggle**: Separate quiet `toggleMutation` (no `onError`), single toast from `.catch()` only
- **RTL bug in English mode**: Removed all hardcoded `dir="rtl"` from shopping components; use `isRTL` from `useTranslation()` for conditional layout
- **UI redesign**: Premium card design, full-width SharingBanner with member avatars, ShareSheet at 90dvh with spacious layout
- **i18n**: All shopping strings (toasts, banners, share UI) routed through `t()` — both `en/` and `he/` translation files updated with 20+ new keys

### Edge Cases — Data Integrity
- **DB migration 10**: `shopping_invitations.invitee_id` changed from `ON DELETE SET NULL` → `ON DELETE CASCADE`; existing NULL zombie rows cleaned up
- **Member removal notification**: When owner removes a member, a `shopping_removed` in-app notification is sent to the removed user
- **Admin user delete**: Gathers affected shared-list members before transaction, sends `shopping_owner_deleted` notification after COMMIT; explicit `DELETE FROM shopping_invitations WHERE invitee_id` as belt-and-suspenders

### Menu / Navigation
- Language toggle button uses `t('common.hebrew')` / `t('common.english')` — no more hardcoded strings
- Shopping card in FAB sheet: `text-left` → `text-start` (RTL-aware text alignment)
- Logout moved from FAB sheet → Profile page (mobile bottom + desktop sidebar)
- FAB settings row: 2-col (theme + language) instead of 3-col

### Android Back Gesture
- `BottomSheet`: pushes a `history` entry on open, listens for `popstate` (Android back gesture) to close the sheet instead of minimizing the app. Programmatic close calls `history.back()` to clean up the entry.

## Test plan
- [ ] Shopping list loads fresh data on every page visit (no stale cache)
- [ ] Toggle bought item — no double toast, optimistic update, rollback on error
- [ ] Switch language to English — shopping card and all UI is LTR
- [ ] Remove member from shared list — removed user gets in-app notification
- [ ] Admin deletes user who owns a shared list — surviving members get notification
- [ ] Android back gesture with FAB sheet open — closes sheet, does not minimize app
- [ ] Android back gesture with shopping share sheet open — closes sheet
- [ ] Logout button appears at bottom of Profile page
- [ ] Language toggle button in FAB sheet shows correct label in both languages

https://claude.ai/code/session_01Qc2RUisWFNTbMbBr2P2kPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc2RUisWFNTbMbBr2P2kPK)_