### PR TITLE
fix(bank-sync): align card statements and isolate agents

### DIFF
--- a/client/src/components/features/bankSync/BankStatsCard.jsx
+++ b/client/src/components/features/bankSync/BankStatsCard.jsx
@@ -52,11 +52,13 @@ export default function BankStatsCard({ stat, connectionId, t, lang }) {
           <p className="text-sm font-bold text-red-500 dark:text-red-400 tabular-nums flex items-center justify-center gap-1">
             <TrendingDown className="w-3.5 h-3.5" />{formatILS(stat.total_expense, lang)}
           </p>
-          <p className="text-[11px] text-gray-500 dark:text-gray-400">{t('expenses')}</p>
+          <p className="text-[11px] text-gray-500 dark:text-gray-400">
+            {isCreditCard ? t('cardCharges') : t('expenses')}
+          </p>
         </div>
       </div>
       <p className="mt-1.5 text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
-        {t('statsScopeNote')}
+        {isCreditCard ? t('cardStatsScopeNote') : t('statsScopeNote')}
       </p>
 
       {/* Accounts + per-account toggle */}

--- a/client/src/components/features/bankSync/ConnectBankModal.jsx
+++ b/client/src/components/features/bankSync/ConnectBankModal.jsx
@@ -133,6 +133,10 @@ const ConnectBankModal = ({
   // bank_source ids that already have a connection: picking one of these
   // replaces its stored credentials (server upserts), so say so.
   existingSources = [],
+  // 'bank' | 'credit_card' | null — banks and credit companies are different
+  // kinds of source, so each gets its own entry button and its own sheet
+  // showing only that kind (same wizard flow either way).
+  kindFilter = null,
 }) => {
   const { t } = useTranslation('bankSync');
   const toast = useToast();
@@ -189,10 +193,25 @@ const ConnectBankModal = ({
 
   const stepTitle = succeeded
     ? t('connected')
-    : [t('stepPickBank'), t('stepCredentials'), t('stepConfirm')][step];
+    : [
+        kindFilter === 'bank'
+          ? t('stepPickBankOnly', { fallback: t('stepPickBank') })
+          : kindFilter === 'credit_card'
+            ? t('stepPickCard', { fallback: t('stepPickBank') })
+            : t('stepPickBank'),
+        t('stepCredentials'),
+        t('stepConfirm'),
+      ][step];
+
+  const modalTitle =
+    kindFilter === 'bank'
+      ? t('addBank')
+      : kindFilter === 'credit_card'
+        ? t('addCard')
+        : t('connectBank');
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={t('connectBank')} sheet drawerWidth={480}>
+    <Modal isOpen={isOpen} onClose={onClose} title={modalTitle} sheet drawerWidth={480}>
       <div className="p-4 space-y-5">
 
         {/* Progress dots */}
@@ -240,7 +259,7 @@ const ConnectBankModal = ({
               {[
                 { kind: 'bank',        title: t('bankAccounts'), icon: Landmark,   provides: t('banksProvide') },
                 { kind: 'credit_card', title: t('creditCards'),  icon: CreditCard, provides: t('cardsProvide') },
-              ].map(({ kind, title, icon: SecIcon, provides }) => {
+              ].filter(({ kind }) => !kindFilter || kind === kindFilter).map(({ kind, title, icon: SecIcon, provides }) => {
                 const list = Object.keys(BANK_FORMS).filter((s) => institutionKind(s) === kind);
                 if (!list.length) return null;
                 return (

--- a/client/src/components/features/bankSync/SyncMethodPanel.jsx
+++ b/client/src/components/features/bankSync/SyncMethodPanel.jsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Laptop, Server, Check, Loader2, Download, KeyRound } from 'lucide-react';
+import { Laptop, Server, Check, Loader2, Download, KeyRound, HelpCircle } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ConfirmModal } from '../../ui';
 import { useToast } from '../../../hooks/useToast';
@@ -27,6 +27,8 @@ export default function SyncMethodPanel({ t, hasConnections }) {
   const queryClient = useQueryClient();
   const [pendingCode, setPendingCode] = useState(null); // { code, expires_at }
   const [confirmAction, setConfirmAction] = useState(null); // 'start' | 'unpair' | null
+  // Tap-friendly help (mobile has no hover) explaining what pairing does.
+  const [showOwnTip, setShowOwnTip] = useState(false);
 
   const { data: pairing = { paired: false }, isLoading } = useQuery({
     queryKey: ['agentPairingStatus'],
@@ -135,8 +137,30 @@ export default function SyncMethodPanel({ t, hasConnections }) {
             <div className="flex items-center gap-2 mb-1">
               <Laptop className="w-4 h-4 text-gray-500 dark:text-gray-400" />
               <p className="text-xs font-bold text-gray-800 dark:text-gray-200">{t('syncMethodOwnTitle')}</p>
+              <button
+                type="button"
+                onClick={() => setShowOwnTip(v => !v)}
+                aria-expanded={showOwnTip}
+                aria-label={t('syncMethodOwnTipLabel')}
+                className="ms-auto p-0.5 rounded-full text-gray-400 hover:text-indigo-500 transition-colors"
+              >
+                <HelpCircle className="w-3.5 h-3.5" />
+              </button>
             </div>
             <p className="text-[11px] text-gray-500 dark:text-gray-400 leading-snug mb-2">{t('syncMethodOwnBody')}</p>
+            {showOwnTip && (
+              <div className="mb-2 rounded-lg bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-100 dark:border-indigo-800/50 px-2.5 py-2 space-y-1">
+                {[1, 2, 3, 4].map((n) => (
+                  <p key={n} className="text-[11px] text-indigo-700 dark:text-indigo-300 leading-snug flex gap-1.5">
+                    <span className="font-bold shrink-0">{n}.</span>
+                    <span>{t(`syncMethodOwnTipStep${n}`)}</span>
+                  </p>
+                ))}
+                <p className="text-[10px] text-indigo-500 dark:text-indigo-400 leading-snug pt-0.5">
+                  {t('syncMethodOwnTipPrivacy')}
+                </p>
+              </div>
+            )}
             <div className="flex flex-col gap-1.5">
               <a
                 href={AGENT_DOWNLOAD_URL}

--- a/client/src/pages/BankSyncPage.jsx
+++ b/client/src/pages/BankSyncPage.jsx
@@ -51,12 +51,16 @@ export default function BankSyncPage() {
   // Set when "update credentials" is clicked on a failed connection —
   // ConnectBankModal then skips the picker and goes straight to that bank.
   const [connectInitialBank, setConnectInitialBank] = useState(null);
+  // 'bank' | 'credit_card' | null — banks and credit companies each get
+  // their own connect button and their own sheet (same wizard, one kind).
+  const [connectKind, setConnectKind] = useState(null);
   const [showCyclePicker, setShowCyclePicker] = useState(false);
   const [showSourceGuide, setShowSourceGuide] = useState(false);
   const [savingCycle, setSavingCycle] = useState(false);
 
-  const openConnect = (bankSource = null) => {
+  const openConnect = (bankSource = null, kind = null) => {
     setConnectInitialBank(bankSource);
+    setConnectKind(kind);
     setShowConnect(true);
   };
 
@@ -145,9 +149,9 @@ export default function BankSyncPage() {
 
   // Shown inside a kind section when the OTHER kind exists but this one doesn't,
   // nudging the user to connect the missing kind (first-run shows the big CTA).
-  const SectionEmptyPrompt = ({ icon: Icon, label, cta }) => (
+  const SectionEmptyPrompt = ({ icon: Icon, label, cta, onClick }) => (
     <button
-      onClick={() => setShowConnect(true)}
+      onClick={onClick}
       className="w-full flex items-center gap-2 py-3 px-3 rounded-xl border border-dashed border-gray-300 dark:border-gray-700 text-left hover:border-indigo-400 dark:hover:border-indigo-600 transition-colors"
     >
       <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center shrink-0">
@@ -307,17 +311,27 @@ export default function BankSyncPage() {
           <div className="space-y-6">
             {/* My connections */}
             <section className="space-y-3">
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between gap-2">
                 <h2 className="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                   {t('myConnections')}
                 </h2>
                 {connections.length > 0 && (
-                  <button
-                    onClick={() => setShowConnect(true)}
-                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary-600 hover:bg-primary-700 text-white text-xs font-semibold transition-colors shadow-sm"
-                  >
-                    <Plus className="w-3.5 h-3.5" /> {t('connectBank')}
-                  </button>
+                  <div className="flex items-center gap-1.5">
+                    {/* Banks and credit companies are different kinds of
+                        source — each gets its own connect button + sheet. */}
+                    <button
+                      onClick={() => openConnect(null, 'bank')}
+                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary-600 hover:bg-primary-700 text-white text-xs font-semibold transition-colors shadow-sm"
+                    >
+                      <Landmark className="w-3.5 h-3.5" /> {t('addBank')}
+                    </button>
+                    <button
+                      onClick={() => openConnect(null, 'credit_card')}
+                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-xs font-semibold transition-colors shadow-sm"
+                    >
+                      <CreditCard className="w-3.5 h-3.5" /> {t('addCard')}
+                    </button>
+                  </div>
                 )}
               </div>
 
@@ -339,17 +353,39 @@ export default function BankSyncPage() {
               )}
 
               {!connsLoading && !connsError && connections.length === 0 && (
-                <motion.button
+                <motion.div
                   initial={{ opacity: 0 }} animate={{ opacity: 1 }}
-                  onClick={() => setShowConnect(true)}
-                  className="w-full text-center py-10 px-6 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-700 hover:border-indigo-400 dark:hover:border-indigo-600 transition-colors group"
+                  className="space-y-3"
                 >
-                  <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 mx-auto mb-3 flex items-center justify-center shadow-sm group-hover:scale-105 transition-transform">
-                    <Plus className="w-7 h-7 text-white" />
+                  <div className="text-center pt-2">
+                    <p className="font-semibold text-gray-800 dark:text-gray-200 mb-1">{t('noConnections')}</p>
+                    <p className="text-sm text-gray-400 dark:text-gray-500">{t('noConnectionsHint')}</p>
                   </div>
-                  <p className="font-semibold text-gray-800 dark:text-gray-200 mb-1">{t('noConnections')}</p>
-                  <p className="text-sm text-gray-400 dark:text-gray-500">{t('noConnectionsHint')}</p>
-                </motion.button>
+                  {/* Two entry points from day one — a bank account and a
+                      credit company are different kinds of source. */}
+                  <div className="grid sm:grid-cols-2 gap-3">
+                    <button
+                      onClick={() => openConnect(null, 'bank')}
+                      className="text-center py-8 px-4 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-700 hover:border-indigo-400 dark:hover:border-indigo-600 transition-colors group"
+                    >
+                      <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-blue-500 to-indigo-600 mx-auto mb-2.5 flex items-center justify-center shadow-sm group-hover:scale-105 transition-transform">
+                        <Landmark className="w-6 h-6 text-white" />
+                      </div>
+                      <p className="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-0.5">{t('addBank')}</p>
+                      <p className="text-xs text-gray-400 dark:text-gray-500">{t('banksProvide')}</p>
+                    </button>
+                    <button
+                      onClick={() => openConnect(null, 'credit_card')}
+                      className="text-center py-8 px-4 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-600 transition-colors group"
+                    >
+                      <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-violet-500 to-purple-600 mx-auto mb-2.5 flex items-center justify-center shadow-sm group-hover:scale-105 transition-transform">
+                        <CreditCard className="w-6 h-6 text-white" />
+                      </div>
+                      <p className="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-0.5">{t('addCard')}</p>
+                      <p className="text-xs text-gray-400 dark:text-gray-500">{t('cardsProvide')}</p>
+                    </button>
+                  </div>
+                </motion.div>
               )}
 
               {hasAnyConnection && (
@@ -363,7 +399,7 @@ export default function BankSyncPage() {
                     ? bankConnections.map(conn => (
                         <BankConnectionCard key={conn.id} conn={conn} t={t} lang={currentLanguage} onUpdateCredentials={openConnect} />
                       ))
-                    : <SectionEmptyPrompt icon={Landmark} label={t('bankSectionEmpty')} cta={t('addBank')} />
+                    : <SectionEmptyPrompt icon={Landmark} label={t('bankSectionEmpty')} cta={t('addBank')} onClick={() => openConnect(null, 'bank')} />
                   }
                 </div>
               )}
@@ -379,7 +415,7 @@ export default function BankSyncPage() {
                     ? cardConnections.map(conn => (
                         <BankConnectionCard key={conn.id} conn={conn} t={t} lang={currentLanguage} onUpdateCredentials={openConnect} />
                       ))
-                    : <SectionEmptyPrompt icon={CreditCard} label={t('cardSectionEmpty')} cta={t('addCard')} />
+                    : <SectionEmptyPrompt icon={CreditCard} label={t('cardSectionEmpty')} cta={t('addCard')} onClick={() => openConnect(null, 'credit_card')} />
                   }
                 </div>
               )}
@@ -439,8 +475,9 @@ export default function BankSyncPage() {
 
       <ConnectBankModal
         isOpen={showConnect}
-        onClose={() => { setShowConnect(false); setConnectInitialBank(null); }}
+        onClose={() => { setShowConnect(false); setConnectInitialBank(null); setConnectKind(null); }}
         initialBank={connectInitialBank}
+        kindFilter={connectKind}
         existingSources={connections.map(c => c.bank_source)}
       />
     </div>

--- a/client/src/translations/en/bankSync.js
+++ b/client/src/translations/en/bankSync.js
@@ -21,6 +21,7 @@ export default {
   // Transaction summary
   income: 'Income',
   expenses: 'Expenses',
+  cardCharges: 'Statement charges',
   netActivity: 'Net Activity',
   transactions: '{{count}} transactions',
   transactionsShort: 'Txns',
@@ -69,6 +70,8 @@ export default {
 
   // Wizard steps
   stepPickBank: 'Choose your bank',
+  stepPickBankOnly: 'Choose your bank',
+  stepPickCard: 'Choose your credit company',
   stepCredentials: 'Login details',
   stepConfirm: 'Review & confirm',
   back: 'Back',
@@ -162,6 +165,12 @@ export default {
   syncMethodDefaultBody: 'No setup — we handle it for you.',
   syncMethodOwnTitle: 'My own computer',
   syncMethodOwnBody: 'Run the SpendWise Agent yourself; only your computer ever sees your bank login.',
+  syncMethodOwnTipLabel: 'How does this work?',
+  syncMethodOwnTipStep1: 'Download the Agent and extract the folder anywhere on your PC.',
+  syncMethodOwnTipStep2: 'Open SpendWiseWorker and tap "Get a pairing code" here.',
+  syncMethodOwnTipStep3: 'Type the code into the Agent — that\'s the whole setup.',
+  syncMethodOwnTipStep4: 'Reconnect your banks; from now on syncs run from this computer.',
+  syncMethodOwnTipPrivacy: 'A paired computer runs ONLY your own account\'s syncs — it can never see or run another user\'s jobs, and your bank login never leaves it.',
   syncMethodDownload: 'Download the Agent',
   syncMethodSmartScreenHint: 'Windows may show a security warning since the app isn’t code-signed yet — click "More info" then "Run anyway".',
   syncMethodGenerateCode: 'Get a pairing code',
@@ -189,6 +198,7 @@ export default {
 
   // Stats card scope — money figures follow the financial period, counts don't
   statsScopeNote: 'Income and expenses cover the current financial period; the transaction count is everything ever synced.',
+  cardStatsScopeNote: 'Statement charges use the debit/payment date reported by the credit company, so cycle-day totals match its statement. The transaction count is everything ever synced.',
 
   // How it works
   howItWorks: 'How does it work?',

--- a/client/src/translations/he/bankSync.js
+++ b/client/src/translations/he/bankSync.js
@@ -21,6 +21,7 @@ export default {
   // Transaction summary
   income: 'הכנסות',
   expenses: 'הוצאות',
+  cardCharges: 'חיובים בדף החשבון',
   netActivity: 'נטו פעילות',
   transactions: '{{count}} תנועות',
   transactionsShort: 'תנועות',
@@ -69,6 +70,8 @@ export default {
 
   // שלבי אשף
   stepPickBank: 'בחר את הבנק שלך',
+  stepPickBankOnly: 'בחר את הבנק שלך',
+  stepPickCard: 'בחר את חברת האשראי שלך',
   stepCredentials: 'פרטי התחברות',
   stepConfirm: 'סיכום ואישור',
   back: 'חזרה',
@@ -162,6 +165,12 @@ export default {
   syncMethodDefaultBody: 'בלי הגדרות - אנחנו מטפלים בזה בשבילך.',
   syncMethodOwnTitle: 'המחשב שלי',
   syncMethodOwnBody: 'מריצים את ה-SpendWise Agent בעצמכם; רק המחשב שלכם רואה את פרטי ההתחברות לבנק.',
+  syncMethodOwnTipLabel: 'איך זה עובד?',
+  syncMethodOwnTipStep1: 'מורידים את ה-Agent ומחלצים את התיקייה לכל מקום במחשב.',
+  syncMethodOwnTipStep2: 'פותחים את SpendWiseWorker ולוחצים כאן על "קבלת קוד חיבור".',
+  syncMethodOwnTipStep3: 'מקלידים את הקוד ב-Agent — וזה כל התהליך.',
+  syncMethodOwnTipStep4: 'מחברים מחדש את הבנקים; מעכשיו הסנכרונים רצים מהמחשב הזה.',
+  syncMethodOwnTipPrivacy: 'מחשב מחובר מריץ אך ורק את הסנכרונים של החשבון שלך — הוא לא יכול לראות או להריץ עבודות של משתמש אחר, ופרטי הבנק לא עוזבים אותו.',
   syncMethodDownload: 'הורדת ה-Agent',
   syncMethodSmartScreenHint: 'ייתכן שווינדוס יציג אזהרת אבטחה כי האפליקציה עדיין לא חתומה דיגיטלית - לחצו על "מידע נוסף" ואז "הפעל בכל זאת".',
   syncMethodGenerateCode: 'קבלת קוד חיבור',
@@ -189,6 +198,7 @@ export default {
 
   // היקף הנתונים בכרטיס הסטטיסטיקה — כסף לפי תקופה, ספירה מאז ומעולם
   statsScopeNote: 'הכנסות והוצאות מתייחסות לתקופה הפיננסית הנוכחית; מונה העסקאות כולל את כל מה שסונכרן אי פעם.',
+  cardStatsScopeNote: 'החיובים מחושבים לפי תאריך החיוב/הפירעון שחברת האשראי דיווחה, כדי שסכום המחזור יתאים לדף החשבון שלה. מונה העסקאות כולל את כל מה שסונכרן אי פעם.',
 
   // איך זה עובד
   howItWorks: 'איך זה עובד?',

--- a/server/DB Migrations/18_job_claimed_by.sql
+++ b/server/DB Migrations/18_job_claimed_by.sql
@@ -1,0 +1,12 @@
+-- ============================================================================
+-- 18_job_claimed_by.sql — record WHICH agent claimed each sync job
+-- ============================================================================
+-- The claim scoping itself is enforced in SQL (a paired device can only ever
+-- claim its own user's jobs; the Default Host only claims jobs of users with
+-- NO active paired device — see routes/bankAgentRoutes.js). This column makes
+-- that visible: 'default-host' or 'device:<label>' per job, so an admin can
+-- verify at a glance that e.g. user 1's jobs never ran on user 41's machine.
+--
+-- Applied to Supabase via MCP apply_migration on 2026-07-10.
+
+ALTER TABLE bank_sync_jobs ADD COLUMN IF NOT EXISTS claimed_by TEXT;

--- a/server/DB Migrations/19_card_statement_dates.sql
+++ b/server/DB Migrations/19_card_statement_dates.sql
@@ -1,0 +1,29 @@
+-- ============================================================================
+-- 19_card_statement_dates.sql -- preserve credit-card debit/payment metadata
+-- ============================================================================
+-- Israeli card scrapers expose both:
+--   * purchase date (`transactions.date`) for spending analytics
+--   * processed/debit date for the card statement and financial-cycle totals
+--
+-- Keeping these separate fixes the cycle-day edge where a purchase made before
+-- the 10th but charged by CAL/Max on the 10th disappeared from the new period.
+-- Status is retained so pending and completed card activity remain auditable.
+-- ============================================================================
+
+ALTER TABLE transactions
+  ADD COLUMN IF NOT EXISTS bank_processed_date DATE,
+  ADD COLUMN IF NOT EXISTS bank_status TEXT;
+
+DO $$
+BEGIN
+  ALTER TABLE transactions
+    ADD CONSTRAINT transactions_bank_status_check
+    CHECK (bank_status IS NULL OR bank_status IN ('pending', 'completed'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_user_source_processed_date
+  ON transactions (user_id, bank_source, bank_processed_date)
+  WHERE deleted_at IS NULL AND bank_source IS NOT NULL;
+

--- a/server/__tests__/agentClaimScope.test.js
+++ b/server/__tests__/agentClaimScope.test.js
@@ -1,0 +1,22 @@
+const { buildAgentClaimScope, auditDeviceLabel } = require('../services/agentClaimScope');
+
+describe('agent claim privacy scope', () => {
+  test('Default Host excludes every user with an active paired device', () => {
+    const scope = buildAgentClaimScope({ global: true }, 5);
+    expect(scope.scopeClause).toContain('NOT EXISTS');
+    expect(scope.scopeClause).toContain("d.status = 'active'");
+    expect(scope.params).toEqual([5, 'default-host']);
+  });
+
+  test('personal device claims only its own user jobs', () => {
+    const scope = buildAgentClaimScope({ userId: 41, label: 'Hananel-PC' }, 3);
+    expect(scope.scopeClause).toBe('AND j2.user_id = $3');
+    expect(scope.params).toEqual([3, 'device:Hananel-PC', 41]);
+  });
+
+  test('rejects an unscoped personal device and sanitizes audit labels', () => {
+    expect(() => buildAgentClaimScope({}, 5)).toThrow('valid user id');
+    expect(auditDeviceLabel('PC\nfor\tuser', 41)).toBe('PC for user');
+  });
+});
+

--- a/server/__tests__/auth.middleware.test.js
+++ b/server/__tests__/auth.middleware.test.js
@@ -171,12 +171,9 @@ describe('canManageUser', () => {
     expect(canManageUser({ role: 'user', id: 1 }, { role: 'user', id: 2 })).toBe(false);
   });
 
-  it('admin+user path returns true even with same id (self-id guard is unreachable dead code)', () => {
-    // NOTE: The self-id guard in canManageUser never fires because the
-    // "admin can manage user" branch returns before reaching it.
-    // This test documents the actual behavior; fixing the guard is a separate task.
-    expect(canManageUser({ role: 'admin', id: 5 }, { role: 'user', id: 5 })).toBe(true);
-    expect(canManageUser({ role: 'super_admin', id: 5 }, { role: 'user', id: 5 })).toBe(true);
+  it('prevents admins and super admins from managing their own account', () => {
+    expect(canManageUser({ role: 'admin', id: 5 }, { role: 'user', id: 5 })).toBe(false);
+    expect(canManageUser({ role: 'super_admin', id: 5 }, { role: 'user', id: 5 })).toBe(false);
   });
 
   it('returns false when either argument is null', () => {

--- a/server/__tests__/bankSyncService.metadata.test.js
+++ b/server/__tests__/bankSyncService.metadata.test.js
@@ -1,0 +1,23 @@
+const {
+  calendarDateInTz,
+  normalizeProcessedDate,
+  normalizeBankStatus,
+} = require('../services/bankSyncService');
+
+describe('bank sync statement metadata', () => {
+  test('keeps an Israeli local-midnight payment on the same calendar day', () => {
+    expect(calendarDateInTz(new Date('2026-07-09T21:00:00.000Z'))).toBe('2026-07-10');
+  });
+
+  test('normalizes a valid processed date and rejects malformed input', () => {
+    expect(normalizeProcessedDate('2026-07-10T00:00:00.000Z')).toBe('2026-07-10');
+    expect(normalizeProcessedDate('not-a-date')).toBeNull();
+    expect(normalizeProcessedDate(null)).toBeNull();
+  });
+
+  test('accepts only scraper-supported transaction statuses', () => {
+    expect(normalizeBankStatus('pending')).toBe('pending');
+    expect(normalizeBankStatus('completed')).toBe('completed');
+    expect(normalizeBankStatus('unknown')).toBeNull();
+  });
+});

--- a/server/controllers/auth/profileController.js
+++ b/server/controllers/auth/profileController.js
@@ -4,12 +4,14 @@
  */
 
 const { User } = require('../../models/User');
+const { UserCache } = require('../../models/UserCache');
 const { clearUserCache } = require('../../middleware/auth');
 const { normalizeUserData } = require('../../utils/userNormalizer');
 const errorCodes = require('../../utils/errorCodes');
 const { asyncHandler } = require('../../middleware/errorHandler');
 const logger = require('../../utils/logger');
 const { getUserFinancialCycle } = require('../../services/financialCycleService');
+const db = require('../../config/db');
 
 const profileController = {
   getFinancialCycle: asyncHandler(async (req, res) => {
@@ -117,6 +119,46 @@ const profileController = {
       });
       throw error;
     }
+  }),
+
+  /**
+   * 🖼️ Persist the uploaded profile picture (storage upload happens in
+   * middleware/upload.js → req.supabaseUpload). Moved out of userRoutes so
+   * routes stay routing-only.
+   * @route POST /api/v1/users/upload-profile-picture
+   */
+  saveProfilePicture: asyncHandler(async (req, res) => {
+    if (!req.supabaseUpload) {
+      return res.status(400).json({
+        success: false,
+        error: { code: 'NO_FILE_UPLOADED', message: 'No file was uploaded' }
+      });
+    }
+
+    const result = await db.query(
+      'UPDATE users SET avatar = $1, profile_picture_url = $2, updated_at = NOW() WHERE id = $3 RETURNING id, avatar, profile_picture_url, onboarding_completed',
+      [req.supabaseUpload.publicUrl, req.supabaseUpload.publicUrl, req.user.id]
+    );
+
+    // Invalidate both cache layers so the next request serves the new avatar
+    UserCache.invalidate(`user:${req.user.id}`);
+    UserCache.invalidate(`${req.user.id}`);
+    clearUserCache(req.user.id);
+
+    logger.info('✅ Profile picture updated', {
+      userId: req.user.id,
+      avatarUrl: req.supabaseUpload.publicUrl
+    });
+
+    res.json({
+      success: true,
+      data: {
+        url: req.supabaseUpload.publicUrl,
+        fileName: req.supabaseUpload.fileName,
+        message: 'Profile picture uploaded successfully',
+        user: result.rows[0]
+      }
+    });
   })
 };
 

--- a/server/routes/bankAgentRoutes.js
+++ b/server/routes/bankAgentRoutes.js
@@ -22,6 +22,7 @@ const crypto = require('crypto');
 const rateLimit = require('express-rate-limit');
 const db = require('../config/db');
 const logger = require('../utils/logger');
+const { buildAgentClaimScope } = require('../services/agentClaimScope');
 const { ingestAccounts } = require('../services/bankSyncService');
 const { enqueueDueJobs } = require('../services/syncSchedulingService');
 
@@ -57,14 +58,14 @@ async function agentAuth(req, res, next) {
       const result = await db.query(
         `UPDATE agent_devices SET last_seen_at = NOW()
          WHERE device_token_hash = $1 AND status = 'active'
-         RETURNING user_id`,
+         RETURNING user_id, label`,
         [hash],
       );
       if (result.rows.length === 0) {
         logger.warn('bank-agent: rejected invalid device token', { ip: req.ip });
         return res.status(401).json({ error: 'Unauthorized' });
       }
-      req.agentScope = { userId: result.rows[0].user_id };
+      req.agentScope = { userId: result.rows[0].user_id, label: result.rows[0].label };
       return next();
     } catch (err) {
       logger.error('bank-agent: device token lookup failed', { error: err.message });
@@ -101,10 +102,10 @@ router.post('/jobs/claim', async (req, res) => {
 
   // Default Host only ever sees users who haven't paired their own device;
   // a paired device only ever sees its own user. Never both, never neither.
-  const scopeClause = req.agentScope.global
-    ? `AND j2.user_id NOT IN (SELECT user_id FROM agent_devices WHERE status = 'active')`
-    : `AND j2.user_id = $2`;
-  const params = req.agentScope.global ? [limit] : [limit, req.agentScope.userId];
+  // The privacy boundary is centralized + unit-tested: Default Host excludes
+  // paired users; a paired device can select only its own user id. The second
+  // parameter is also persisted as the per-job audit label.
+  const { scopeClause, params } = buildAgentClaimScope(req.agentScope, limit);
 
   try {
     await enqueueDueJobs();
@@ -112,7 +113,8 @@ router.post('/jobs/claim', async (req, res) => {
     const result = await db.query(
       `UPDATE bank_sync_jobs j SET
          status = 'running',
-         started_at = NOW()
+         started_at = NOW(),
+         claimed_by = $2
        FROM (
          SELECT j2.id FROM bank_sync_jobs j2
          JOIN bank_connections c2 ON c2.id = j2.connection_id

--- a/server/routes/bankConnectionsRoutes.js
+++ b/server/routes/bankConnectionsRoutes.js
@@ -72,6 +72,7 @@ router.get('/', async (req, res) => {
               j.trigger      AS latest_job_trigger,
               j.requested_at AS latest_job_requested_at,
               j.result       AS latest_job_result,
+              j.claimed_by   AS latest_job_claimed_by,
               q.manual_today,
               q.last_done_sync_at,
               CASE
@@ -80,7 +81,7 @@ router.get('/', async (req, res) => {
               END AS next_manual_sync_at
        FROM bank_connections c
        LEFT JOIN LATERAL (
-         SELECT status, trigger, requested_at, result
+         SELECT status, trigger, requested_at, result, claimed_by
          FROM bank_sync_jobs
          WHERE connection_id = c.id
          ORDER BY requested_at DESC
@@ -356,7 +357,7 @@ router.get('/jobs', async (req, res) => {
   try {
     const result = await db.query(
       `SELECT j.id, j.connection_id, j.status, j.trigger, j.requested_at,
-              j.finished_at, j.result, c.bank_source
+              j.finished_at, j.result, j.claimed_by, c.bank_source
        FROM bank_sync_jobs j
        JOIN bank_connections c ON c.id = j.connection_id
        WHERE j.user_id = $1

--- a/server/routes/bankSyncRoutes.js
+++ b/server/routes/bankSyncRoutes.js
@@ -30,8 +30,12 @@ const db = require('../config/db');
 const logger = require('../utils/logger');
 const { auth } = require('../middleware/auth');
 const { ingestAccounts, MAX_TXNS } = require('../services/bankSyncService');
-const { VALID_SOURCES } = require('../config/institutions');
+const { VALID_SOURCES, INSTITUTIONS, institutionKind } = require('../config/institutions');
 const { getUserFinancialCycle } = require('../services/financialCycleService');
+
+const CREDIT_CARD_SOURCES = Object.entries(INSTITUTIONS)
+  .filter(([, meta]) => meta.kind === 'credit_card')
+  .map(([source]) => source);
 
 // ── Strict rate limiter ───────────────────────────────────────────────────────
 // Tighter than the main API limiter: this endpoint should only be called by
@@ -166,7 +170,13 @@ router.get('/stats', auth, async (req, res) => {
          WHERE user_id = $1
        ),
        tx AS (
-         SELECT t.*
+         SELECT
+           t.*,
+           CASE
+             WHEN t.bank_source = ANY($4::text[])
+               THEN COALESCE(t.bank_processed_date, t.date)
+             ELSE t.date
+           END AS activity_date
          FROM transactions t
          LEFT JOIN bank_accounts ba_filter
            ON ba_filter.user_id = t.user_id
@@ -182,10 +192,10 @@ router.get('/stats', auth, async (req, res) => {
            bank_source AS source,
            COUNT(id)::int AS total,
            MAX(created_at) AS last_transaction_sync,
-           COALESCE(SUM(CASE WHEN type='income'  AND date >= $2 AND date < $3 THEN 1 ELSE 0 END), 0)::int AS income_count,
-           COALESCE(SUM(CASE WHEN type='expense' AND date >= $2 AND date < $3 THEN 1 ELSE 0 END), 0)::int AS expense_count,
-           COALESCE(SUM(CASE WHEN type='income'  AND date >= $2 AND date < $3 THEN amount ELSE 0 END), 0) AS total_income,
-           COALESCE(SUM(CASE WHEN type='expense' AND date >= $2 AND date < $3 THEN amount ELSE 0 END), 0) AS total_expense
+           COALESCE(SUM(CASE WHEN type='income'  AND activity_date >= $2 AND activity_date < $3 THEN 1 ELSE 0 END), 0)::int AS income_count,
+           COALESCE(SUM(CASE WHEN type='expense' AND activity_date >= $2 AND activity_date < $3 THEN 1 ELSE 0 END), 0)::int AS expense_count,
+           COALESCE(SUM(CASE WHEN type='income'  AND activity_date >= $2 AND activity_date < $3 THEN amount ELSE 0 END), 0) AS total_income,
+           COALESCE(SUM(CASE WHEN type='expense' AND activity_date >= $2 AND activity_date < $3 THEN amount ELSE 0 END), 0) AS total_expense
          FROM tx
          GROUP BY bank_source
        ),
@@ -205,9 +215,9 @@ router.get('/stats', auth, async (req, res) => {
            bank_source AS source,
            COALESCE(bank_account_number, '') AS account_number,
            COUNT(id)::int AS total,
-           MAX(date) AS last_transaction_at,
-           COALESCE(SUM(CASE WHEN type='income'  AND date >= $2 AND date < $3 THEN amount ELSE 0 END), 0) AS total_income,
-           COALESCE(SUM(CASE WHEN type='expense' AND date >= $2 AND date < $3 THEN amount ELSE 0 END), 0) AS total_expense
+           MAX(activity_date) AS last_transaction_at,
+           COALESCE(SUM(CASE WHEN type='income'  AND activity_date >= $2 AND activity_date < $3 THEN amount ELSE 0 END), 0) AS total_income,
+           COALESCE(SUM(CASE WHEN type='expense' AND activity_date >= $2 AND activity_date < $3 THEN amount ELSE 0 END), 0) AS total_expense
          FROM tx
          GROUP BY bank_source, COALESCE(bank_account_number, '')
        )
@@ -241,9 +251,8 @@ router.get('/stats', auth, async (req, res) => {
        LEFT JOIN tx_stats ts ON ts.source = s.source
        LEFT JOIN acct_stats ast ON ast.source = s.source
        ORDER BY last_sync DESC`,
-      [userId, period.start, period.end],
+      [userId, period.start, period.end, CREDIT_CARD_SOURCES],
     );
-    const { institutionKind, INSTITUTIONS } = require('../config/institutions');
     const sources = result.rows.map((r) => ({
       ...r,
       kind: institutionKind(r.source),

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -170,57 +170,7 @@ router.put('/profile',
 router.post('/upload-profile-picture',
   auth,
   uploadProfilePicture,
-  async (req, res) => {
-    try {
-      if (!req.supabaseUpload) {
-        return res.status(400).json({
-          success: false,
-          error: {
-            code: 'NO_FILE_UPLOADED',
-            message: 'No file was uploaded'
-          }
-        });
-      }
-
-      // Update user's avatar in database - FIXED: Preserve onboarding_completed
-      const db = require('../config/db');
-      const { UserCache } = require('../models/UserCache');
-      const result = await db.query(
-        'UPDATE users SET avatar = $1, profile_picture_url = $2, updated_at = NOW() WHERE id = $3 RETURNING id, avatar, profile_picture_url, onboarding_completed',
-        [req.supabaseUpload.publicUrl, req.supabaseUpload.publicUrl, req.user.id]
-      );
-
-      // Invalidate user cache so the next request picks up the new avatar
-      UserCache.invalidate(`user:${req.user.id}`);
-      UserCache.invalidate(`${req.user.id}`);
-
-      logger.info('✅ Profile picture - Database updated:', {
-        userId: req.user.id,
-        avatarUrl: req.supabaseUpload.publicUrl,
-        updatedUser: result.rows[0],
-        onboardingPreserved: result.rows[0].onboarding_completed
-      });
-
-      res.json({
-        success: true,
-        data: {
-          url: req.supabaseUpload.publicUrl,
-          fileName: req.supabaseUpload.fileName,
-          message: 'Profile picture uploaded successfully',
-          user: result.rows[0]
-        }
-      });
-    } catch (error) {
-      logger.error('❌ Profile picture upload route error:', error.message);
-      res.status(500).json({
-        success: false,
-        error: {
-          code: 'UPLOAD_ROUTE_ERROR',
-          message: 'Failed to process profile picture upload'
-        }
-      });
-    }
-  }
+  profileController.saveProfilePicture
 );
 
 /**

--- a/server/services/agentClaimScope.js
+++ b/server/services/agentClaimScope.js
@@ -1,0 +1,40 @@
+/**
+ * Build the SQL scope and audit label for an agent job claim.
+ *
+ * The shared Default Host may claim only users who do not have an active
+ * personal device. A paired device may claim only its own user's jobs.
+ * Keeping this policy in a pure helper makes the privacy boundary directly
+ * unit-testable instead of burying it inside an Express route.
+ */
+
+function auditDeviceLabel(label, userId) {
+  return String(label || userId)
+    .replace(/[\r\n\t]+/g, ' ')
+    .trim()
+    .slice(0, 80);
+}
+
+function buildAgentClaimScope(agentScope, limit) {
+  if (agentScope?.global === true) {
+    return {
+      scopeClause: `AND NOT EXISTS (
+        SELECT 1 FROM agent_devices d
+        WHERE d.user_id = j2.user_id AND d.status = 'active'
+      )`,
+      params: [limit, 'default-host'],
+    };
+  }
+
+  const userId = Number(agentScope?.userId);
+  if (!Number.isInteger(userId) || userId <= 0) {
+    throw new Error('Paired agent scope requires a valid user id');
+  }
+
+  return {
+    scopeClause: 'AND j2.user_id = $3',
+    params: [limit, `device:${auditDeviceLabel(agentScope.label, userId)}`, userId],
+  };
+}
+
+module.exports = { buildAgentClaimScope, auditDeviceLabel };
+

--- a/server/services/bankSyncService.js
+++ b/server/services/bankSyncService.js
@@ -25,6 +25,16 @@ function calendarDateInTz(d) {
   }).format(d);
 }
 
+function normalizeProcessedDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : calendarDateInTz(date);
+}
+
+function normalizeBankStatus(value) {
+  return value === 'pending' || value === 'completed' ? value : null;
+}
+
 /**
  * Ingest scraped accounts for a user inside an existing DB transaction.
  *
@@ -85,6 +95,8 @@ async function ingestAccounts(client, userId, source, accounts) {
       // Source-provided category text (Max sends one; banks usually don't).
       // null when absent — we never guess a category at ingest time.
       const rawCategory = (txn.raw_category || '').toString().trim().slice(0, 200) || null;
+      const bankProcessedDate = normalizeProcessedDate(txn.processed_date);
+      const bankStatus = normalizeBankStatus(txn.status);
       const bankSyncId = txn.identifier ? `${source}:${acctKey}:${txn.identifier}` : null;
 
       const acctNum = acctKey === 'default' ? null : acctKey;
@@ -94,21 +106,32 @@ async function ingestAccounts(client, userId, source, accounts) {
         const result = await client.query(
           `INSERT INTO transactions
              (user_id, amount, type, description, notes, date, transaction_datetime,
-              raw_category, bank_sync_id, bank_source, bank_account_number, created_at, updated_at)
-           VALUES ($1,$2,$3,$4,'',$5,$6,$7,$8,$9,$10,NOW(),NOW())
+              raw_category, bank_sync_id, bank_source, bank_account_number,
+              bank_processed_date, bank_status, created_at, updated_at)
+           VALUES ($1,$2,$3,$4,'',$5,$6,$7,$8,$9,$10,$11,$12,NOW(),NOW())
            ON CONFLICT (user_id, bank_sync_id)
              WHERE bank_sync_id IS NOT NULL
-           DO NOTHING
-           RETURNING id`,
-          [userId, amount, type, description, date, transactionDatetime, rawCategory, bankSyncId, source, acctNum],
+           DO UPDATE SET
+             bank_processed_date = COALESCE(EXCLUDED.bank_processed_date, transactions.bank_processed_date),
+             bank_status         = COALESCE(EXCLUDED.bank_status, transactions.bank_status),
+             raw_category        = COALESCE(transactions.raw_category, EXCLUDED.raw_category),
+             updated_at          = NOW()
+           WHERE transactions.bank_processed_date IS DISTINCT FROM COALESCE(EXCLUDED.bank_processed_date, transactions.bank_processed_date)
+              OR transactions.bank_status IS DISTINCT FROM COALESCE(EXCLUDED.bank_status, transactions.bank_status)
+              OR transactions.raw_category IS DISTINCT FROM COALESCE(transactions.raw_category, EXCLUDED.raw_category)
+           RETURNING id, (xmax = 0) AS was_inserted`,
+          [
+            userId, amount, type, description, date, transactionDatetime,
+            rawCategory, bankSyncId, source, acctNum, bankProcessedDate, bankStatus,
+          ],
         );
-        result.rows.length > 0 ? inserted++ : skipped++;
+        result.rows[0]?.was_inserted ? inserted++ : skipped++;
       } else {
         // Soft dedup: match on (user_id, source, account, date, amount, description).
         // Deliberately INCLUDES tombstoned rows (deleted_at set): a user-deleted
         // bank transaction must keep blocking re-import, not resurrect here.
         const existing = await client.query(
-          `SELECT id FROM transactions
+          `SELECT id, bank_processed_date, bank_status, raw_category FROM transactions
            WHERE user_id=$1 AND bank_source=$2 AND date=$3
              AND amount=$4 AND description=$5
              AND bank_account_number IS NOT DISTINCT FROM $6
@@ -116,14 +139,34 @@ async function ingestAccounts(client, userId, source, accounts) {
           [userId, source, date, amount, description, acctNum],
         );
         if (existing.rows.length > 0) {
+          // A deduped re-sync can still enrich an old row with statement date
+          // and status metadata introduced after that row was first imported.
+          await client.query(
+            `UPDATE transactions SET
+               bank_processed_date = COALESCE($2, bank_processed_date),
+               bank_status         = COALESCE($3, bank_status),
+               raw_category        = COALESCE(raw_category, $4),
+               updated_at          = NOW()
+             WHERE id = $1
+               AND (
+                 bank_processed_date IS DISTINCT FROM COALESCE($2, bank_processed_date)
+                 OR bank_status IS DISTINCT FROM COALESCE($3, bank_status)
+                 OR raw_category IS DISTINCT FROM COALESCE(raw_category, $4)
+               )`,
+            [existing.rows[0].id, bankProcessedDate, bankStatus, rawCategory],
+          );
           skipped++;
         } else {
           await client.query(
             `INSERT INTO transactions
                (user_id, amount, type, description, notes, date, transaction_datetime,
-                raw_category, bank_source, bank_account_number, created_at, updated_at)
-             VALUES ($1,$2,$3,$4,'',$5,$6,$7,$8,$9,NOW(),NOW())`,
-            [userId, amount, type, description, date, transactionDatetime, rawCategory, source, acctNum],
+                raw_category, bank_source, bank_account_number,
+                bank_processed_date, bank_status, created_at, updated_at)
+             VALUES ($1,$2,$3,$4,'',$5,$6,$7,$8,$9,$10,$11,NOW(),NOW())`,
+            [
+              userId, amount, type, description, date, transactionDatetime,
+              rawCategory, source, acctNum, bankProcessedDate, bankStatus,
+            ],
           );
           inserted++;
         }
@@ -161,4 +204,10 @@ async function ingestAccounts(client, userId, source, accounts) {
   return { inserted, skipped };
 }
 
-module.exports = { ingestAccounts, MAX_TXNS };
+module.exports = {
+  ingestAccounts,
+  MAX_TXNS,
+  calendarDateInTz,
+  normalizeProcessedDate,
+  normalizeBankStatus,
+};


### PR DESCRIPTION
## What changed
- preserve card-company debit/payment dates separately from purchase dates
- calculate Bank Sync card totals using statement dates while keeping dashboard spending on purchase dates
- enrich already-deduped transactions on the next sync
- add the production migration and statement-date index
- enforce and audit Default Host vs personal-device claim scoping
- finish the separate bank/card connection sheets, pairing help, translations, and profile-route cleanup
- update the stale self-management security test

## Root cause
CAL and Max return both a purchase date and a processed/payment date. The agent discarded the payment date, so on cycle day 10 transactions purchased before the 10th disappeared from the current card total even though the statement was charged on the 10th.

## Validation
- server: 130/130 Jest tests
- client: production build passes
- client: lint has zero errors (existing warnings only)
- Supabase migration applied and conflict-enrichment SQL verified inside a rolled-back transaction
- Vercel production baseline READY with no runtime errors